### PR TITLE
Increase test coverage

### DIFF
--- a/src/CometHelpers.sol
+++ b/src/CometHelpers.sol
@@ -10,7 +10,7 @@ contract CometHelpers is CometMath {
     uint64 internal constant BASE_INDEX_SCALE = 1e15;
     uint64 internal constant BASE_ACCRUAL_SCALE = 1e6;
 
-    error LackAllowance();
+    error InsufficientAllowance();
     error ZeroShares();
     error ZeroAssets();
     error ZeroAddress();

--- a/src/CometWrapper.sol
+++ b/src/CometWrapper.sol
@@ -119,10 +119,10 @@ contract CometWrapper is ERC4626, CometHelpers {
 
             if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
         }
-        // Asset transfers in Comet may lead to decrease of this contract's principal/shares by 1 more than the 
+        // Asset transfers in Comet may lead to decrease of this contract's principal/shares by 1 more than the
         // `shares` argument. Taking into account this quirk in Comet's transfer logic, we always decrease `shares`
         // by 1 before converting to assets and doing the transfer. We then proceed to burn the actual `shares` amount
-        // that was decreased during the Comet transfer. 
+        // that was decreased during the Comet transfer.
         // In this way, any rounding error would be in favor of CometWrapper and CometWrapper will be protected
         // from insolvency due to lack of assets that can be withdrawn by users.
         assets = convertToAssets(shares-1);
@@ -155,7 +155,7 @@ contract CometWrapper is ERC4626, CometHelpers {
     function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
         uint256 allowed = msg.sender == from ? type(uint256).max : allowance[from][msg.sender]; // Saves gas for limited approvals.
 
-        if (allowed < amount) revert LackAllowance();
+        if (allowed < amount) revert InsufficientAllowance();
         if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
 
         transferInternal(from, to, amount);
@@ -178,7 +178,7 @@ contract CometWrapper is ERC4626, CometHelpers {
 
     /// @notice Total assets of an account that are managed by this vault
     /// @dev The asset balance is computed from an account's shares balance which mirrors how Comet
-    /// computes token balances. This is done this way since balances are ever-increasing due to 
+    /// computes token balances. This is done this way since balances are ever-increasing due to
     /// interest accrual.
     /// @param account The address to be queried
     /// @return The total amount of assets held by an account
@@ -304,7 +304,7 @@ contract CometWrapper is ERC4626, CometHelpers {
     /// @notice Returns the amount of assets that the Vault would exchange for the amount of shares provided, in an ideal
     /// scenario where all the conditions are met.
     /// @dev Treats shares as principal and computes for assets by taking into account interest accrual. Relies on latest
-    /// `baseSupplyIndex` from Comet which is the global index used for interest accrual the from supply rate. 
+    /// `baseSupplyIndex` from Comet which is the global index used for interest accrual the from supply rate.
     /// @param shares The amount of shares to be converted to assets
     /// @return The total amount of assets computed from the given shares
     function convertToAssets(uint256 shares) public view override returns (uint256) {

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -5,6 +5,11 @@ import {BaseTest, CometHelpers, CometWrapper, ERC20, ICometRewards} from "./Base
 import {CometMath} from "../src/vendor/CometMath.sol";
 
 contract CometWrapperTest is BaseTest, CometMath {
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
     function setUp() public override {
         super.setUp();
 
@@ -17,7 +22,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertGt(comet.balanceOf(bob), 9999e6);
     }
 
-    function test__constructor() public {
+    function test_constructor() public {
         assertEq(cometWrapper.trackingIndexScale(), comet.trackingIndexScale());
         assertEq(address(cometWrapper.comet()), address(comet));
         assertEq(address(cometWrapper.cometRewards()), address(cometRewards));
@@ -29,7 +34,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertEq(cometWrapper.totalAssets(), 0);
     }
 
-    function test__constructorRevertsOnInvalidComet() public {
+    function test_constructorRevertsOnInvalidComet() public {
         // reverts on zero address
         vm.expectRevert();
         new CometWrapper(ERC20(address(0)), cometRewards, "Name", "Symbol");
@@ -43,7 +48,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         new CometWrapper(usdc, cometRewards, "Name", "Symbol");
     }
 
-    function test__constructorRevertsOnInvalidCometRewards() public {
+    function test_constructorRevertsOnInvalidCometRewards() public {
         // reverts on zero address
         vm.expectRevert(CometHelpers.ZeroAddress.selector);
         new CometWrapper(ERC20(address(comet)), ICometRewards(address(0)), "Name", "Symbol");
@@ -53,7 +58,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         new CometWrapper(ERC20(address(comet)), ICometRewards(address(1)), "Name", "Symbol");
     }
 
-    function test__totalAssets() public {
+    function test_totalAssets() public {
         assertEq(cometWrapper.totalAssets(), 0);
 
         vm.startPrank(alice);
@@ -75,7 +80,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
     }
 
-    function test__nullifyInflationAttacks() public {
+    function test_nullifyInflationAttacks() public {
         assertEq(cometWrapper.totalAssets(), 0);
 
         vm.startPrank(alice);
@@ -94,9 +99,11 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertLt(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
     }
 
-    function test__deposit() public {
+    function test_deposit() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(alice, alice, 5_000e6, cometWrapper.convertToShares(5_000e6));
         cometWrapper.deposit(5_000e6, alice);
         vm.stopPrank();
 
@@ -106,6 +113,8 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(bob, bob, 7_777e6, cometWrapper.convertToShares(7_777e6));
         cometWrapper.deposit(7_777e6, bob);
         vm.stopPrank();
 
@@ -115,7 +124,9 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertLe(totalAssets, cometWrapper.totalAssets());
     }
 
-    function test__withdraw() public {
+    // TODO: test deposit to
+
+    function test_withdraw() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         cometWrapper.deposit(9_101e6, alice);
@@ -138,51 +149,69 @@ contract CometWrapperTest is BaseTest, CometMath {
         skip(500 days);
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
 
-        uint256 totalAssets = cometWrapper.maxWithdraw(alice) + cometWrapper.maxWithdraw(bob);
+        uint256 aliceAssets = cometWrapper.maxWithdraw(alice);
+        uint256 bobAssets = cometWrapper.maxWithdraw(bob);
+        uint256 totalAssets = aliceAssets + bobAssets;
         assertLe(totalAssets, cometWrapper.totalAssets());
 
         vm.startPrank(alice);
+        // TODO: investigate!
+        // Due to rounding errors when updating principal, sometimes maxWithdraw may be off by 1
+        vm.expectEmit(true, true, true, true);
+        emit Withdraw(alice, alice, alice, aliceAssets, cometWrapper.convertToShares(aliceAssets) + 1);
         cometWrapper.withdraw(cometWrapper.maxWithdraw(alice), alice, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         // Due to rounding errors when updating principal, sometimes maxWithdraw may be off by 1
         // This edge case appears when zeroing out the assets from the Wrapper contract
+        vm.expectEmit(true, true, true, true);
+        emit Withdraw(bob, bob, bob, bobAssets, cometWrapper.convertToShares(bobAssets) + 1);
         cometWrapper.withdraw(cometWrapper.maxWithdraw(bob), bob, bob);
         vm.stopPrank();
     }
 
-    function test__mint() public {
+    // TODO: test withdraw from and to
+    // TODO: test withdrawing not a max amount
+
+    // TODO: turn into fuzz, like test_redeem
+    function test_mint() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
+        vm.expectEmit(true, true, true, true);
+        // TODO: fix
+        emit Deposit(alice, alice, cometWrapper.convertToAssets(9_000e6), 9_000e6 - 1);
         cometWrapper.mint(9_000e6, alice);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
+        // TODO: fix so it's always equal!
         assertApproxEqAbs(cometWrapper.balanceOf(alice), 9_000e6, 1);
+        // Make sure Alice never receives more shares than intended
+        assertLe(cometWrapper.balanceOf(alice), 9_000e6);
         assertEq(cometWrapper.maxRedeem(alice), cometWrapper.balanceOf(alice));
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
+        vm.expectEmit(true, true, true, true);
+        // TODO: fix
+        emit Deposit(bob, bob, cometWrapper.convertToAssets(7_777e6), 7_777e6 - 1);
         cometWrapper.mint(7_777e6, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
+        // TODO: fix so it's always equal!
         assertApproxEqAbs(cometWrapper.balanceOf(bob), 7_777e6, 1);
+        // Make sure Bob never receives more shares than intended
+        assertLe(cometWrapper.balanceOf(bob), 7_777e6);
 
         uint256 totalAssets = cometWrapper.maxWithdraw(bob) + cometWrapper.maxWithdraw(alice);
-        assertLe(totalAssets, cometWrapper.totalAssets());
-
-        vm.startPrank(bob);
-        cometWrapper.redeem(cometWrapper.maxRedeem(bob), bob, bob);
-        vm.stopPrank();
-
-        vm.startPrank(alice);
-        cometWrapper.redeem(cometWrapper.maxRedeem(alice), alice, alice);
-        vm.stopPrank();
+        assertEq(totalAssets, cometWrapper.totalAssets());
     }
 
-    function test__redeem(uint256 amount1, uint256 amount2) public {
+    // TODO: test mint to
+
+    function test_redeem(uint256 amount1, uint256 amount2) public {
         amount1 = bound(amount1, 5, 10_000e6);
         amount2 = bound(amount2, 5, 10_000e6);
 
@@ -207,19 +236,32 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         skip(500 days);
 
+        uint256 aliceShares = cometWrapper.maxRedeem(alice);
+        uint256 bobShares = cometWrapper.maxRedeem(bob);
+
         // All users can fully redeem shares
-        vm.startPrank(alice);
-        cometWrapper.redeem(cometWrapper.maxRedeem(alice), alice, alice);
-        vm.stopPrank();
-        vm.startPrank(bob);
-        cometWrapper.redeem(cometWrapper.maxRedeem(bob), bob, bob);
-        vm.stopPrank();
+        vm.expectEmit(true, true, true, true);
+        // TODO: investigate round down
+        emit Withdraw(alice, alice, alice, cometWrapper.convertToAssets(aliceShares) - 1, aliceShares);
+        vm.prank(alice);
+        cometWrapper.redeem(aliceShares, alice, alice);
+
+        vm.expectEmit(true, true, true, true);
+        // TODO: investigate round down of shares... this should not happen
+        emit Withdraw(bob, bob, bob, cometWrapper.convertToAssets(bobShares) - 1, bobShares);
+        vm.prank(bob);
+        cometWrapper.redeem(bobShares, bob, bob);
 
         assertEq(cometWrapper.totalSupply(), unsigned104(comet.userBasic(wrapperAddress).principal));
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
     }
 
-    function test__disallowZeroSharesOrAssets() public {
+    // TODO: test redeem from and to
+    // TODO: test redeeming not a max amount
+
+    // TODO: can remove? is there a need for these checks?
+    // TODO: maybe to prevent 0 shares minting non-zero values? add fuzz tests to verify this can't happen
+    function test_disallowZeroSharesOrAssets() public {
         vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.mint(0, alice);
         vm.expectRevert(CometHelpers.ZeroShares.selector);
@@ -230,12 +272,13 @@ contract CometWrapperTest is BaseTest, CometMath {
         cometWrapper.deposit(0, alice);
     }
 
-    function test__transfer() public {
+    function test_transfer() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         cometWrapper.mint(9_000e6, alice);
         cometWrapper.transferFrom(alice, bob, 1_337e6);
         vm.stopPrank();
+
         assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663e6, 1);
         assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337e6, 1);
         assertApproxEqAbs(cometWrapper.totalSupply(), 9_000e6, 1);
@@ -245,8 +288,14 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(bob, alice, 777e6);
         cometWrapper.transfer(alice, 777e6);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(bob, alice, 111e6);
         cometWrapper.transfer(alice, 111e6);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(bob, alice, 99e6);
         cometWrapper.transfer(alice, 99e6);
         vm.stopPrank();
 
@@ -255,50 +304,55 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         skip(30 days);
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
+        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000e6, 1);
         uint256 totalPrincipal = unsigned256(comet.userBasic(address(cometWrapper)).principal);
         assertEq(cometWrapper.totalSupply(), totalPrincipal);
     }
 
-    function test__transferFromWorksForSender() public {
+    function test_transferFromWorksForSender() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         cometWrapper.mint(5_000e6, alice);
 
         cometWrapper.transferFrom(alice, bob, 2_500e6);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500e6, 1);
         vm.stopPrank();
+
+        // TODO: investigate why this gets rounded down...i think because mint is rounded down. need to verify
+        assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500e6, 1);
+        assertEq(cometWrapper.balanceOf(bob), 2_500e6);
     }
 
-    function test__transferFromRespectsAllowances() public {
+    function test_transferFromUsesAllowances() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         cometWrapper.mint(5_000e6, alice);
         vm.stopPrank();
 
         // Need approvals to transferFrom alice to bob
-        vm.startPrank(bob);
-        vm.expectRevert(CometHelpers.LackAllowance.selector);
+        vm.prank(bob);
+        vm.expectRevert(CometHelpers.InsufficientAllowance.selector);
         cometWrapper.transferFrom(alice, bob, 5_000e6);
-        vm.stopPrank();
 
         vm.prank(alice);
-        cometWrapper.approve(bob, 2_500e6);
+        cometWrapper.approve(bob, 2_700e6);
 
         vm.startPrank(bob);
         // Allowances should be updated when transferFrom is done
-        assertEq(cometWrapper.allowance(alice, bob), 2_500e6);
+        assertEq(cometWrapper.allowance(alice, bob), 2_700e6);
         cometWrapper.transferFrom(alice, bob, 2_500e6);
         assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500e6, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), 2_500e6, 1);
+        assertEq(cometWrapper.balanceOf(bob), 2_500e6);
 
-        vm.expectRevert(CometHelpers.LackAllowance.selector);
+        // Reverts if trying to transferFrom again now that allowance is used up
+        vm.expectRevert(CometHelpers.InsufficientAllowance.selector);
         cometWrapper.transferFrom(alice, bob, 2_500e6);
         vm.stopPrank();
-        assertEq(cometWrapper.allowance(alice, bob), 0);
+        assertEq(cometWrapper.allowance(alice, bob), 200e6);
 
         // Infinite allowance does not decrease allowance
         vm.prank(bob);
         cometWrapper.approve(alice, type(uint256).max);
+        assertEq(cometWrapper.allowance(bob, alice), type(uint256).max);
 
         vm.startPrank(alice);
         cometWrapper.transferFrom(bob, alice, 1_000e6);
@@ -306,27 +360,33 @@ contract CometWrapperTest is BaseTest, CometMath {
         vm.stopPrank();
     }
 
-    function test__transferFromRevertsOnLackingAllowance() public {
+    function test_transferFrom_revertInsufficientAllowance() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(1_000e6, alice);
+        cometWrapper.mint(1_000e6, alice);
         vm.stopPrank();
 
-        vm.startPrank(bob);
-        vm.expectRevert(CometHelpers.LackAllowance.selector);
+        vm.prank(bob);
+        vm.expectRevert(CometHelpers.InsufficientAllowance.selector);
         cometWrapper.transferFrom(alice, bob, 900e6);
-        vm.stopPrank();
 
         vm.prank(alice);
-        cometWrapper.approve(bob, 4_000e6);
+        cometWrapper.approve(bob, 500e6);
 
         vm.startPrank(bob);
-        vm.expectRevert();
-        cometWrapper.transferFrom(alice, bob, 2_000e6);
-        cometWrapper.transferFrom(alice, bob, 900e6);
-        vm.expectRevert();
-        cometWrapper.transferFrom(alice, bob, 3_000e6);
-        assertEq(cometWrapper.balanceOf(bob), 900e6);
+        vm.expectRevert(CometHelpers.InsufficientAllowance.selector);
+        cometWrapper.transferFrom(alice, bob, 800e6); // larger than allowance
+
+        cometWrapper.transferFrom(alice, bob, 400e6); // less than allowance
+
+        vm.expectRevert(CometHelpers.InsufficientAllowance.selector);
+        cometWrapper.transferFrom(alice, bob, 200e6); // larger than remaining allowance
+
+        assertEq(cometWrapper.balanceOf(bob), 400e6);
+        assertEq(cometWrapper.allowance(alice, bob), 100e6);
         vm.stopPrank();
     }
 }
+
+// TODO: add fuzz testing
+// TODO: allow tests

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -34,7 +34,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertEq(cometWrapper.totalAssets(), 0);
     }
 
-    function test_constructorRevertsOnInvalidComet() public {
+    function test_constructor_revertsOnInvalidComet() public {
         // reverts on zero address
         vm.expectRevert();
         new CometWrapper(ERC20(address(0)), cometRewards, "Name", "Symbol");
@@ -48,7 +48,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         new CometWrapper(usdc, cometRewards, "Name", "Symbol");
     }
 
-    function test_constructorRevertsOnInvalidCometRewards() public {
+    function test_constructor_revertsOnInvalidCometRewards() public {
         // reverts on zero address
         vm.expectRevert(CometHelpers.ZeroAddress.selector);
         new CometWrapper(ERC20(address(comet)), ICometRewards(address(0)), "Name", "Symbol");
@@ -94,7 +94,7 @@ contract CometWrapperTest is BaseTest, CometMath {
     }
 
     function test_previewDeposit() public {
-        assertEq(cometWrapper.balanceOf(alice), 0e6);
+        assertEq(cometWrapper.balanceOf(alice), 0);
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 alicePreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
@@ -110,7 +110,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertEq(alicePreviewedSharesReceived, aliceActualSharesReceived);
         assertEq(alicePreviewedSharesReceived, aliceSharesFromAssets);
 
-        assertEq(cometWrapper.balanceOf(bob), 0e6);
+        assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobPreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
@@ -130,7 +130,7 @@ contract CometWrapperTest is BaseTest, CometMath {
     }
 
     function test_previewMint() public {
-        assertEq(cometWrapper.balanceOf(alice), 0e6);
+        assertEq(cometWrapper.balanceOf(alice), 0);
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 alicePreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
@@ -147,7 +147,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertEq(alicePreviewedAssetsUsed, aliceAssetsFromShares);
         assertApproxEqAbs(cometWrapper.balanceOf(alice), 5_000e6, 1);
 
-        assertEq(cometWrapper.balanceOf(bob), 0e6);
+        assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobPreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
@@ -439,7 +439,7 @@ contract CometWrapperTest is BaseTest, CometMath {
 
     // TODO: can remove? is there a need for these checks?
     // TODO: maybe to prevent 0 shares minting non-zero values? add fuzz tests to verify this can't happen
-    function test_disallowZeroSharesOrAssets() public {
+    function test_revertsOnZeroSharesOrAssets() public {
         vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.mint(0, alice);
         vm.expectRevert(CometHelpers.ZeroShares.selector);
@@ -538,7 +538,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         vm.stopPrank();
     }
 
-    function test_transferFrom_revertInsufficientAllowance() public {
+    function test_transferFrom_revertsOnInsufficientAllowance() public {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         cometWrapper.mint(1_000e6, alice);


### PR DESCRIPTION
Add test coverage for events and `preview` functions. 

We also change the `LackAllowance()` custom error to be `InsufficientAllowance()` instead.