### PR TITLE
Properly calculate shares/assets in withdraw and redeem

### DIFF
--- a/src/CometWrapper.sol
+++ b/src/CometWrapper.sol
@@ -354,8 +354,7 @@ contract CometWrapper is ERC4626, CometHelpers {
         uint256 newBalance = totalAssets() - assets;
         // Round down so accounting is in the wrapper's favor
         uint104 newPrincipal = principalValueSupply(baseSupplyIndex_, newBalance, Rounding.DOWN);
-        uint256 shares = currentPrincipal - newPrincipal;
-        return shares;
+        return currentPrincipal - newPrincipal;
     }
 
     /// @notice Allows an on-chain or off-chain user to simulate the effects of their redemption at the current block,
@@ -369,8 +368,7 @@ contract CometWrapper is ERC4626, CometHelpers {
         uint256 newPrincipal = currentPrincipal - shares;
         // Round up so accounting is in the wrapper's favor
         uint256 newBalance = presentValueSupply(baseSupplyIndex_, newPrincipal, Rounding.UP);
-        uint256 assets = totalAssets() - newBalance;
-        return assets;
+        return totalAssets() - newBalance;
     }
 
     function convertToAssetsInternal(uint256 shares, Rounding rounding) internal view returns (uint256) {

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -98,7 +98,7 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 alicePreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
-        uint256 aliceSharesFromAssets = cometWrapper.convertToShares(5_000e6);
+        uint256 aliceConvertToShares = cometWrapper.convertToShares(5_000e6);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
@@ -108,13 +108,13 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance - 5_000e6, 1);
         assertEq(cometWrapper.balanceOf(alice), alicePreviewedSharesReceived);
         assertEq(alicePreviewedSharesReceived, aliceActualSharesReceived);
-        assertEq(alicePreviewedSharesReceived, aliceSharesFromAssets);
+        assertEq(alicePreviewedSharesReceived, aliceConvertToShares);
 
         assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobPreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
-        uint256 bobSharesFromAssets = cometWrapper.convertToShares(5_000e6);
+        uint256 bobConvertToShares = cometWrapper.convertToShares(5_000e6);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
@@ -126,7 +126,7 @@ contract CometWrapperTest is BaseTest, CometMath {
         assertApproxEqAbs(cometWrapper.balanceOf(bob), bobPreviewedSharesReceived, 1);
         assertApproxEqAbs(bobPreviewedSharesReceived, bobActualSharesReceived, 1);
         assertGe(bobPreviewedSharesReceived, bobActualSharesReceived);
-        assertEq(bobPreviewedSharesReceived, bobSharesFromAssets);
+        assertEq(bobPreviewedSharesReceived, bobConvertToShares);
     }
 
     function test_previewMint() public {
@@ -134,7 +134,7 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 alicePreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
-        uint256 aliceAssetsFromShares = cometWrapper.convertToAssets(5_000e6);
+        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(5_000e6);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
@@ -143,15 +143,15 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         // TODO: investigate rounding
         assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance - alicePreviewedAssetsUsed, 1);
-        assertEq(alicePreviewedAssetsUsed, aliceActualAssetsUsed);
-        assertEq(alicePreviewedAssetsUsed, aliceAssetsFromShares);
+        assertApproxEqAbs(alicePreviewedAssetsUsed, aliceActualAssetsUsed, 1);
+        assertApproxEqAbs(alicePreviewedAssetsUsed, aliceConvertToAssets, 1);
         assertApproxEqAbs(cometWrapper.balanceOf(alice), 5_000e6, 1);
 
         assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobPreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
-        uint256 bobAssetsFromShares = cometWrapper.convertToAssets(5_000e6);
+        uint256 bobConvertToAssets = cometWrapper.convertToAssets(5_000e6);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
@@ -160,8 +160,8 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         // TODO: investigate rounding
         assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance - bobPreviewedAssetsUsed, 1);
-        assertEq(bobPreviewedAssetsUsed, bobActualAssetsUsed);
-        assertEq(bobPreviewedAssetsUsed, bobAssetsFromShares);
+        assertApproxEqAbs(bobPreviewedAssetsUsed, bobActualAssetsUsed, 1);
+        assertApproxEqAbs(bobPreviewedAssetsUsed, bobConvertToAssets, 1);
         // TODO: rounded down by 2 instead of 1
         assertApproxEqAbs(cometWrapper.balanceOf(bob), 5_000e6, 2);
     }
@@ -180,36 +180,40 @@ contract CometWrapperTest is BaseTest, CometMath {
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 aliceWrapperBalance = cometWrapper.balanceOf(alice);
         uint256 alicePreviewedSharesUsed = cometWrapper.previewWithdraw(2_500e6);
-        uint256 aliceSharesFromAssets = cometWrapper.convertToShares(2_500e6);
+        uint256 aliceConvertToShares = cometWrapper.convertToShares(2_500e6);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         uint256 aliceActualSharesUsed = cometWrapper.withdraw(2_500e6, alice, alice);
         vm.stopPrank();
 
-        // TODO: investigate rounding
+        // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + 2_500e6, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), aliceWrapperBalance - alicePreviewedSharesUsed, 1);
-        assertApproxEqAbs(alicePreviewedSharesUsed, aliceActualSharesUsed, 1);
-        assertLe(alicePreviewedSharesUsed, aliceActualSharesUsed);
-        assertEq(alicePreviewedSharesUsed, aliceSharesFromAssets);
+        assertLe(comet.balanceOf(alice), aliceCometBalance + 2_500e6);
+        assertEq(cometWrapper.balanceOf(alice), aliceWrapperBalance - alicePreviewedSharesUsed);
+        assertEq(alicePreviewedSharesUsed, aliceActualSharesUsed);
+        // The value from convertToShares is <= the value from previewRedeem because it doesn't account
+        // for "slippage" that occurs during integer math rounding
+        assertGe(alicePreviewedSharesUsed, aliceConvertToShares);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobWrapperBalance = cometWrapper.balanceOf(bob);
         uint256 bobPreviewedSharesUsed = cometWrapper.previewWithdraw(2_500e6);
-        uint256 bobSharesFromAssets = cometWrapper.convertToShares(2_500e6);
+        uint256 bobConvertToShares = cometWrapper.convertToShares(2_500e6);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
         uint256 bobActualSharesUsed = cometWrapper.withdraw(2_500e6, bob, bob);
         vm.stopPrank();
 
-        // TODO: investigate rounding
+        // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + 2_500e6, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), bobWrapperBalance - bobPreviewedSharesUsed, 1);
-        assertApproxEqAbs(bobPreviewedSharesUsed, bobActualSharesUsed, 1);
-        assertLe(bobPreviewedSharesUsed, bobActualSharesUsed);
-        assertEq(bobPreviewedSharesUsed, bobSharesFromAssets);
+        assertLe(comet.balanceOf(bob), bobCometBalance + 2_500e6);
+        assertEq(cometWrapper.balanceOf(bob), bobWrapperBalance - bobPreviewedSharesUsed);
+        assertEq(bobPreviewedSharesUsed, bobActualSharesUsed);
+        // The value from convertToShares is <= the value from previewRedeem because it doesn't account
+        // for "slippage" that occurs during integer math rounding
+        assertGe(bobPreviewedSharesUsed, bobConvertToShares);
     }
 
     function test_previewRedeem() public {
@@ -226,36 +230,40 @@ contract CometWrapperTest is BaseTest, CometMath {
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 aliceWrapperBalance = cometWrapper.balanceOf(alice);
         uint256 alicePreviewedAssetsReceived = cometWrapper.previewRedeem(2_500e6);
-        uint256 aliceAssetsFromShares = cometWrapper.convertToAssets(2_500e6);
+        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(2_500e6);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         uint256 aliceActualAssetsReceived = cometWrapper.redeem(2_500e6, alice, alice);
         vm.stopPrank();
 
-        // TODO: investigate rounding
-        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + alicePreviewedAssetsReceived, 2);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), aliceWrapperBalance - 2_500e6, 1);
-        assertApproxEqAbs(alicePreviewedAssetsReceived, aliceActualAssetsReceived, 1);
-        assertGe(alicePreviewedAssetsReceived, aliceActualAssetsReceived);
-        assertEq(alicePreviewedAssetsReceived, aliceAssetsFromShares);
+        // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
+        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + alicePreviewedAssetsReceived, 1);
+        assertLe(comet.balanceOf(alice), aliceCometBalance + alicePreviewedAssetsReceived);
+        assertEq(cometWrapper.balanceOf(alice), aliceWrapperBalance - 2_500e6);
+        assertEq(alicePreviewedAssetsReceived, aliceActualAssetsReceived);
+        // The value from convertToAssets is >= the value from previewRedeem because it doesn't account
+        // for "slippage" that occurs during integer math rounding
+        assertLe(alicePreviewedAssetsReceived, aliceConvertToAssets);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobWrapperBalance = cometWrapper.balanceOf(bob);
         uint256 bobPreviewedAssetsReceived = cometWrapper.previewRedeem(2_500e6);
-        uint256 bobAssetsFromShares = cometWrapper.convertToAssets(2_500e6);
+        uint256 bobConvertToAssets = cometWrapper.convertToAssets(2_500e6);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
         uint256 bobActualAssetsReceived = cometWrapper.redeem(2_500e6, bob, bob);
         vm.stopPrank();
 
-        // TODO: investigate rounding
-        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + bobPreviewedAssetsReceived, 2);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), bobWrapperBalance - 2_500e6, 1);
-        assertApproxEqAbs(bobPreviewedAssetsReceived, bobActualAssetsReceived, 1);
-        assertGe(bobPreviewedAssetsReceived, bobActualAssetsReceived);
-        assertEq(bobPreviewedAssetsReceived, bobAssetsFromShares);
+        // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
+        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + bobPreviewedAssetsReceived, 1);
+        assertLe(comet.balanceOf(bob), bobCometBalance + bobPreviewedAssetsReceived);
+        assertEq(cometWrapper.balanceOf(bob), bobWrapperBalance - 2_500e6);
+        assertEq(bobPreviewedAssetsReceived, bobActualAssetsReceived);
+        // The value from convertToAssets is >= the value from previewRedeem because it doesn't account
+        // for "slippage" that occurs during integer math rounding
+        assertLe(bobPreviewedAssetsReceived, bobConvertToAssets);
     }
 
     function test_nullifyInflationAttacks() public {
@@ -598,14 +606,14 @@ contract CometWrapperTest is BaseTest, CometMath {
 
         // All users can fully redeem shares
         uint256 aliceSharesToAssets = cometWrapper.convertToAssets(aliceShares);
-        uint256 aliceAssetsWithdrawn = calculateAssetsToWithdrawFromShares(aliceShares);
+        uint256 aliceAssetsWithdrawn = cometWrapper.previewRedeem(aliceShares);
         vm.expectEmit(true, true, true, true);
         emit Withdraw(alice, alice, alice, aliceAssetsWithdrawn, aliceShares);
         vm.prank(alice);
         cometWrapper.redeem(aliceShares, alice, alice);
 
         uint256 bobSharesToAssets = cometWrapper.convertToAssets(bobShares);
-        uint256 bobAssetsWithdrawn = calculateAssetsToWithdrawFromShares(bobShares);
+        uint256 bobAssetsWithdrawn = cometWrapper.previewRedeem(bobShares);
         vm.expectEmit(true, true, true, true);
         emit Withdraw(bob, bob, bob, bobAssetsWithdrawn, bobShares);
         vm.prank(bob);

--- a/test/CometWrapperInvariant.t.sol
+++ b/test/CometWrapperInvariant.t.sol
@@ -36,14 +36,32 @@ contract CometWrapperInvariantTest is BaseTest, CometMath {
 
         skip(10000 days);
 
-        vm.startPrank(bob);
-        cometWrapper.mint(bobBalance/3, bob);
-        vm.stopPrank();
+        vm.prank(alice);
+        cometWrapper.mint(aliceBalance/3, alice);
         assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
 
-        vm.startPrank(alice);
-        cometWrapper.mint(aliceBalance/3, alice);
-        vm.stopPrank();
+        vm.prank(bob);
+        cometWrapper.mint(bobBalance/3, bob);
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
+
+        assertEq(cometWrapper.balanceOf(alice) + cometWrapper.balanceOf(bob), unsigned256(comet.userBasic(address(cometWrapper)).principal));
+
+        vm.prank(alice);
+        cometWrapper.withdraw(aliceBalance/4, alice, alice);
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
+
+        vm.prank(bob);
+        cometWrapper.withdraw(bobBalance/4, bob, bob);
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
+
+        assertEq(cometWrapper.balanceOf(alice) + cometWrapper.balanceOf(bob), unsigned256(comet.userBasic(address(cometWrapper)).principal));
+
+        vm.prank(alice);
+        cometWrapper.redeem(aliceBalance/5, alice, alice);
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
+
+        vm.prank(bob);
+        cometWrapper.redeem(bobBalance/5, bob, bob);
         assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
 
         assertEq(cometWrapper.balanceOf(alice) + cometWrapper.balanceOf(bob), unsigned256(comet.userBasic(address(cometWrapper)).principal));
@@ -51,10 +69,14 @@ contract CometWrapperInvariantTest is BaseTest, CometMath {
         vm.startPrank(alice);
         cometWrapper.redeem(cometWrapper.maxRedeem(alice), alice, alice);
         vm.stopPrank();
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
 
         vm.startPrank(bob);
         cometWrapper.redeem(cometWrapper.maxRedeem(bob), bob, bob);
         vm.stopPrank();
+        assertEq(comet.balanceOf(address(cometWrapper)), cometWrapper.totalAssets());
+
+        assertEq(cometWrapper.balanceOf(alice) + cometWrapper.balanceOf(bob), unsigned256(comet.userBasic(address(cometWrapper)).principal));
     }
 
     // Invariants:


### PR DESCRIPTION
**Changes in this PR**
- Improve calculation of shares and assets
  - Calculate the shares/assets locally instead of making two contract calls to `Comet`
  - Local calculations allow us to delay transferring out assets until the end of the function to avoid potential re-entrancy attacks
  - `previewRedeem/Withdraw` now return exact amounts, where the previous implementation would give values that could be off by 2 gwei
  - Avoid having to hardcode any logic (e.g. "subtract 1 from shares to redeem") by always rounding up or down in the wrapper's favor
- Make `redeem` conform to the ERC-4626 spec by making it burn exact `shares` instead of `shares-1`
- Remove all uses of named return variables
- Add invariant tests for `redeem` to ensure correct accounting of shares

**Explanation**
The old logic for calculating 1) `assets` to withdraw in `redeem` and  2) `shares` to redeem in `withdraw` is pretty wonky. 

It makes two contract calls to Comet to get the `principal` value pre and post transfer in order to calculate the diff. This diff in `principal` can actually be calculated locally, which helps to save a good amount of gas and allows us to transfer assets out at the end of the function to avoid any potential re-entrancy attacks. The old logic for `redeem` also does not conform to the ERC-4626 spec, as the function does not burn the exact amount of `shares` specified by the caller (it burns `shares - 1` instead). This lead to weird rounding behaviors, where some balances were off by 2 wei instead of 1 wei.

The new logic for shares/assets calculation improves upon the old implementation by calculating all the values locally to gain all the benefits discussed above. It also makes sure that `redeem` now conforms to the ERC-4626 spec and will always burn the exact amount of `shares` specified by the caller.
