### PR TITLE
Remove redundant check for zero assets

### DIFF
--- a/src/CometHelpers.sol
+++ b/src/CometHelpers.sol
@@ -17,7 +17,6 @@ contract CometHelpers is CometMath {
 
     error InsufficientAllowance();
     error ZeroShares();
-    error ZeroAssets();
     error ZeroAddress();
     error TimestampTooLarge();
 

--- a/src/CometWrapper.sol
+++ b/src/CometWrapper.sol
@@ -52,8 +52,6 @@ contract CometWrapper is ERC4626, CometHelpers {
     /// @param receiver The recipient address of the minted shares
     /// @return The amount of shares that are minted to the receiver
     function deposit(uint256 assets, address receiver) public override returns (uint256) {
-        if (assets == 0) revert ZeroAssets();
-
         asset.safeTransferFrom(msg.sender, address(this), assets);
 
         accrueInternal(receiver);
@@ -76,7 +74,6 @@ contract CometWrapper is ERC4626, CometHelpers {
 
         accrueInternal(receiver);
         uint256 assets = previewMint(shares);
-        if (assets == 0) revert ZeroAssets();
 
         asset.safeTransferFrom(msg.sender, address(this), assets);
         _mint(receiver, shares);
@@ -93,8 +90,6 @@ contract CometWrapper is ERC4626, CometHelpers {
     /// @param owner The owner of the assets to be withdrawn
     /// @return The amount of shares of the owner that are burned
     function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
-        if (assets == 0) revert ZeroAssets();
-
         accrueInternal(owner);
         uint256 shares = previewWithdraw(assets);
         if (shares == 0) revert ZeroShares();
@@ -133,7 +128,6 @@ contract CometWrapper is ERC4626, CometHelpers {
 
         accrueInternal(owner);
         uint256 assets = previewRedeem(shares);
-        if (assets == 0) revert ZeroAssets();
 
         _burn(owner, shares);
         asset.safeTransfer(receiver, assets);

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -784,17 +784,18 @@ contract CometWrapperTest is BaseTest, CometMath {
         cometWrapper.redeem(900e6, bob, alice);
     }
 
-    // TODO: can remove? is there a need for these checks?
-    // TODO: maybe to prevent 0 shares minting non-zero values? add fuzz tests to verify this can't happen
-    function test_revertsOnZeroSharesOrAssets() public {
+    function test_revertsOnZeroShares() public {
+        vm.startPrank(alice);
+        comet.allow(wrapperAddress, true);
         vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.mint(0, alice);
         vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.redeem(0, alice, alice);
-        vm.expectRevert(CometHelpers.ZeroAssets.selector);
+        vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.withdraw(0, alice, alice);
-        vm.expectRevert(CometHelpers.ZeroAssets.selector);
+        vm.expectRevert(CometHelpers.ZeroShares.selector);
         cometWrapper.deposit(0, alice);
+        vm.stopPrank();
     }
 
     function test_transfer() public {


### PR DESCRIPTION
We already check for zero shares, so these zero asset checks are redundant.