### PR TITLE
Add cWETHv3 tests and generalize tests to work on assets with any decimals

### DIFF
--- a/test/BaseUSDbCTest.t.sol
+++ b/test/BaseUSDbCTest.t.sol
@@ -7,7 +7,7 @@ import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract BaseTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
     string public override NETWORK = "base";
     uint256 public override FORK_BLOCK_NUMBER = 4791144;
 
@@ -16,7 +16,7 @@ contract BaseTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
     address public override CONFIGURATOR_ADDRESS = 0x45939657d1CA34A8FA39A924B71D28Fe8431e581;
     address public override PROXY_ADMIN_ADDRESS = 0xbdE8F31D2DdDA895264e27DD990faB3DC87b372d;
     address public override COMP_ADDRESS = 0x9e1028F5F1D5eDE59748FFceE5532509976840E0;
-    address public override USDC_ADDRESS = 0x4c80E24119CFB836cdF0a6b53dc23F04F7e652CA;
-    address public override USDC_HOLDER = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
+    address public override USDC_ADDRESS = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
+    address public override USDC_HOLDER = 0x4c80E24119CFB836cdF0a6b53dc23F04F7e652CA;
     address public override CUSDC_HOLDER = 0xBaC3100BEEE79CA34B18fbcD0437bd382Ee5611B;
 }

--- a/test/BaseUSDbCTest.t.sol
+++ b/test/BaseUSDbCTest.t.sol
@@ -16,7 +16,7 @@ contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTe
     address public override CONFIGURATOR_ADDRESS = 0x45939657d1CA34A8FA39A924B71D28Fe8431e581;
     address public override PROXY_ADMIN_ADDRESS = 0xbdE8F31D2DdDA895264e27DD990faB3DC87b372d;
     address public override COMP_ADDRESS = 0x9e1028F5F1D5eDE59748FFceE5532509976840E0;
-    address public override USDC_ADDRESS = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
-    address public override USDC_HOLDER = 0x4c80E24119CFB836cdF0a6b53dc23F04F7e652CA;
-    address public override CUSDC_HOLDER = 0xBaC3100BEEE79CA34B18fbcD0437bd382Ee5611B;
+    address public override UNDERLYING_TOKEN_ADDRESS = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
+    address public override UNDERLYING_TOKEN_HOLDER = 0x4c80E24119CFB836cdF0a6b53dc23F04F7e652CA;
+    address public override COMET_HOLDER = 0xBaC3100BEEE79CA34B18fbcD0437bd382Ee5611B;
 }

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -11,13 +11,17 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
     event Approval(address indexed owner, address indexed spender, uint256 amount);
 
     function setUpAliceAndBobCometBalances() public {
-        vm.prank(cusdcHolder);
-        comet.transfer(alice, 10_000e6);
-        assertGt(comet.balanceOf(alice), 9999e6);
+        deal(address(usdc), address(cusdcHolder), 20_000 * decimalScale);
+        vm.startPrank(cusdcHolder);
+        usdc.approve(address(comet), 20_000 * decimalScale);
+        comet.supply(address(usdc), 20_000 * decimalScale);
 
-        vm.prank(cusdcHolder);
-        comet.transfer(bob, 10_000e6);
-        assertGt(comet.balanceOf(bob), 9999e6);
+        comet.transfer(alice, 10_000 * decimalScale);
+        assertGt(comet.balanceOf(alice), 9999 * decimalScale);
+
+        comet.transfer(bob, 10_000 * decimalScale);
+        assertGt(comet.balanceOf(bob), 9999 * decimalScale);
+        vm.stopPrank();
     }
 
     function test_constructor() public {
@@ -63,7 +67,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, alice);
+        cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -72,7 +76,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, bob);
+        cometWrapper.deposit(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -87,12 +91,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, alice);
+        cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
-        assertApproxEqAbs(cometWrapper.underlyingBalance(alice), 5_000e6, 1);
+        assertApproxEqAbs(cometWrapper.underlyingBalance(alice), 5_000 * decimalScale, 1);
         skip(14 days);
-        assertGe(cometWrapper.underlyingBalance(alice), 5_000e6);
+        assertGe(cometWrapper.underlyingBalance(alice), 5_000 * decimalScale);
     }
 
     function test_previewDeposit() public {
@@ -101,17 +105,17 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.balanceOf(alice), 0);
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
-        uint256 alicePreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
-        uint256 aliceConvertToShares = cometWrapper.convertToShares(5_000e6);
+        uint256 alicePreviewedSharesReceived = cometWrapper.previewDeposit(5_000 * decimalScale);
+        uint256 aliceConvertToShares = cometWrapper.convertToShares(5_000 * decimalScale);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        uint256 aliceActualSharesReceived = cometWrapper.deposit(5_000e6, alice);
+        uint256 aliceActualSharesReceived = cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
-        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance - 5_000e6, 1);
-        assertLe(comet.balanceOf(alice), aliceCometBalance - 5_000e6);
+        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance - 5_000 * decimalScale, 1);
+        assertLe(comet.balanceOf(alice), aliceCometBalance - 5_000 * decimalScale);
         assertEq(cometWrapper.balanceOf(alice), alicePreviewedSharesReceived);
         assertEq(alicePreviewedSharesReceived, aliceActualSharesReceived);
         // previewDeposit should be <= convertToShares to account
@@ -121,17 +125,17 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
-        uint256 bobPreviewedSharesReceived = cometWrapper.previewDeposit(5_000e6);
-        uint256 bobConvertToShares = cometWrapper.convertToShares(5_000e6);
+        uint256 bobPreviewedSharesReceived = cometWrapper.previewDeposit(5_000 * decimalScale);
+        uint256 bobConvertToShares = cometWrapper.convertToShares(5_000 * decimalScale);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        uint256 bobActualSharesReceived = cometWrapper.deposit(5_000e6, bob);
+        uint256 bobActualSharesReceived = cometWrapper.deposit(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
-        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance - 5_000e6, 1);
-        assertLe(comet.balanceOf(bob), bobCometBalance - 5_000e6);
+        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance - 5_000 * decimalScale, 1);
+        assertLe(comet.balanceOf(bob), bobCometBalance - 5_000 * decimalScale);
         assertEq(cometWrapper.balanceOf(bob), bobPreviewedSharesReceived);
         assertEq(bobPreviewedSharesReceived, bobActualSharesReceived);
         // previewDeposit should be <= convertToShares to account
@@ -145,16 +149,16 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.balanceOf(alice), 0);
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
-        uint256 alicePreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
-        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(5_000e6);
+        uint256 alicePreviewedAssetsUsed = cometWrapper.previewMint(5_000 * decimalScale);
+        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(5_000 * decimalScale);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        uint256 aliceActualAssetsUsed = cometWrapper.mint(5_000e6, alice);
+        uint256 aliceActualAssetsUsed = cometWrapper.mint(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         // Mints exact shares
-        assertEq(cometWrapper.balanceOf(alice), 5_000e6);
+        assertEq(cometWrapper.balanceOf(alice), 5_000 * decimalScale);
         // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance - alicePreviewedAssetsUsed, 1);
         assertLe(comet.balanceOf(alice), aliceCometBalance - alicePreviewedAssetsUsed);
@@ -166,16 +170,16 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.balanceOf(bob), 0);
 
         uint256 bobCometBalance = comet.balanceOf(bob);
-        uint256 bobPreviewedAssetsUsed = cometWrapper.previewMint(5_000e6);
-        uint256 bobConvertToAssets = cometWrapper.convertToAssets(5_000e6);
+        uint256 bobPreviewedAssetsUsed = cometWrapper.previewMint(5_000 * decimalScale);
+        uint256 bobConvertToAssets = cometWrapper.convertToAssets(5_000 * decimalScale);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        uint256 bobActualAssetsUsed = cometWrapper.mint(5_000e6, bob);
+        uint256 bobActualAssetsUsed = cometWrapper.mint(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         // Mints exact shares
-        assertEq(cometWrapper.balanceOf(bob), 5_000e6);
+        assertEq(cometWrapper.balanceOf(bob), 5_000 * decimalScale);
         // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance - bobPreviewedAssetsUsed, 1);
         assertLe(comet.balanceOf(bob), bobCometBalance - bobPreviewedAssetsUsed);
@@ -190,27 +194,27 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, alice);
+        cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, bob);
+        cometWrapper.deposit(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 aliceWrapperBalance = cometWrapper.balanceOf(alice);
-        uint256 alicePreviewedSharesUsed = cometWrapper.previewWithdraw(2_500e6);
-        uint256 aliceConvertToShares = cometWrapper.convertToShares(2_500e6);
+        uint256 alicePreviewedSharesUsed = cometWrapper.previewWithdraw(2_500 * decimalScale);
+        uint256 aliceConvertToShares = cometWrapper.convertToShares(2_500 * decimalScale);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        uint256 aliceActualSharesUsed = cometWrapper.withdraw(2_500e6, alice, alice);
+        uint256 aliceActualSharesUsed = cometWrapper.withdraw(2_500 * decimalScale, alice, alice);
         vm.stopPrank();
 
         // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
-        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + 2_500e6, 1);
-        assertLe(comet.balanceOf(alice), aliceCometBalance + 2_500e6);
+        assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + 2_500 * decimalScale, 1);
+        assertLe(comet.balanceOf(alice), aliceCometBalance + 2_500 * decimalScale);
         assertEq(cometWrapper.balanceOf(alice), aliceWrapperBalance - alicePreviewedSharesUsed);
         assertEq(alicePreviewedSharesUsed, aliceActualSharesUsed);
         // The value from convertToShares is <= the value from previewRedeem because it doesn't account
@@ -219,17 +223,17 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobWrapperBalance = cometWrapper.balanceOf(bob);
-        uint256 bobPreviewedSharesUsed = cometWrapper.previewWithdraw(2_500e6);
-        uint256 bobConvertToShares = cometWrapper.convertToShares(2_500e6);
+        uint256 bobPreviewedSharesUsed = cometWrapper.previewWithdraw(2_500 * decimalScale);
+        uint256 bobConvertToShares = cometWrapper.convertToShares(2_500 * decimalScale);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        uint256 bobActualSharesUsed = cometWrapper.withdraw(2_500e6, bob, bob);
+        uint256 bobActualSharesUsed = cometWrapper.withdraw(2_500 * decimalScale, bob, bob);
         vm.stopPrank();
 
         // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
-        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + 2_500e6, 1);
-        assertLe(comet.balanceOf(bob), bobCometBalance + 2_500e6);
+        assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + 2_500 * decimalScale, 1);
+        assertLe(comet.balanceOf(bob), bobCometBalance + 2_500 * decimalScale);
         assertEq(cometWrapper.balanceOf(bob), bobWrapperBalance - bobPreviewedSharesUsed);
         assertEq(bobPreviewedSharesUsed, bobActualSharesUsed);
         // The value from convertToShares is <= the value from previewRedeem because it doesn't account
@@ -242,28 +246,28 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, alice);
+        cometWrapper.mint(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, bob);
+        cometWrapper.mint(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 aliceWrapperBalance = cometWrapper.balanceOf(alice);
-        uint256 alicePreviewedAssetsReceived = cometWrapper.previewRedeem(2_500e6);
-        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(2_500e6);
+        uint256 alicePreviewedAssetsReceived = cometWrapper.previewRedeem(2_500 * decimalScale);
+        uint256 aliceConvertToAssets = cometWrapper.convertToAssets(2_500 * decimalScale);
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        uint256 aliceActualAssetsReceived = cometWrapper.redeem(2_500e6, alice, alice);
+        uint256 aliceActualAssetsReceived = cometWrapper.redeem(2_500 * decimalScale, alice, alice);
         vm.stopPrank();
 
         // Alice loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(alice), aliceCometBalance + alicePreviewedAssetsReceived, 1);
         assertLe(comet.balanceOf(alice), aliceCometBalance + alicePreviewedAssetsReceived);
-        assertEq(cometWrapper.balanceOf(alice), aliceWrapperBalance - 2_500e6);
+        assertEq(cometWrapper.balanceOf(alice), aliceWrapperBalance - 2_500 * decimalScale);
         assertEq(alicePreviewedAssetsReceived, aliceActualAssetsReceived);
         // The value from convertToAssets is >= the value from previewRedeem because it doesn't account
         // for "slippage" that occurs during integer math rounding
@@ -271,18 +275,18 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         uint256 bobCometBalance = comet.balanceOf(bob);
         uint256 bobWrapperBalance = cometWrapper.balanceOf(bob);
-        uint256 bobPreviewedAssetsReceived = cometWrapper.previewRedeem(2_500e6);
-        uint256 bobConvertToAssets = cometWrapper.convertToAssets(2_500e6);
+        uint256 bobPreviewedAssetsReceived = cometWrapper.previewRedeem(2_500 * decimalScale);
+        uint256 bobConvertToAssets = cometWrapper.convertToAssets(2_500 * decimalScale);
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        uint256 bobActualAssetsReceived = cometWrapper.redeem(2_500e6, bob, bob);
+        uint256 bobActualAssetsReceived = cometWrapper.redeem(2_500 * decimalScale, bob, bob);
         vm.stopPrank();
 
         // Bob loses 1 gwei of the underlying due to Comet rounding during transfers
         assertApproxEqAbs(comet.balanceOf(bob), bobCometBalance + bobPreviewedAssetsReceived, 1);
         assertLe(comet.balanceOf(bob), bobCometBalance + bobPreviewedAssetsReceived);
-        assertEq(cometWrapper.balanceOf(bob), bobWrapperBalance - 2_500e6);
+        assertEq(cometWrapper.balanceOf(bob), bobWrapperBalance - 2_500 * decimalScale);
         assertEq(bobPreviewedAssetsReceived, bobActualAssetsReceived);
         // The value from convertToAssets is >= the value from previewRedeem because it doesn't account
         // for "slippage" that occurs during integer math rounding
@@ -296,7 +300,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(5_000e6, alice);
+        cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         uint256 oldTotalAssets = cometWrapper.totalAssets();
@@ -304,7 +308,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         // totalAssets can not be manipulated, effectively nullifying inflation attacks
         vm.prank(bob);
-        comet.transfer(wrapperAddress, 5_000e6);
+        comet.transfer(wrapperAddress, 5_000 * decimalScale);
         // totalAssets does not change when doing a direct transfer
         assertEq(cometWrapper.totalAssets(), oldTotalAssets);
         assertLt(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -313,10 +317,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
     function test_deposit(uint256 amount1, uint256 amount2) public {
         setUpAliceAndBobCometBalances();
 
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount2 <= 2**48);
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(amount1 > 100e6 && amount2 > 100e6);
+        (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);
@@ -354,8 +355,8 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         vm.expectEmit(true, true, true, true);
-        emit Deposit(alice, bob, 5_000e6, cometWrapper.previewDeposit(5_000e6));
-        cometWrapper.deposit(5_000e6, bob);
+        emit Deposit(alice, bob, 5_000 * decimalScale, cometWrapper.previewDeposit(5_000 * decimalScale));
+        cometWrapper.deposit(5_000 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -365,8 +366,8 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
         vm.expectEmit(true, true, true, true);
-        emit Deposit(bob, alice, 7_777e6, cometWrapper.previewDeposit(7_777e6));
-        cometWrapper.deposit(7_777e6, alice);
+        emit Deposit(bob, alice, 7_777 * decimalScale, cometWrapper.previewDeposit(7_777 * decimalScale));
+        cometWrapper.deposit(7_777 * decimalScale, alice);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -380,12 +381,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(9_101e6, alice);
+        cometWrapper.deposit(9_101 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(2_555e6, bob);
+        cometWrapper.deposit(2_555 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -394,7 +395,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
 
         vm.prank(alice);
-        cometWrapper.withdraw(173e6, alice, alice);
+        cometWrapper.withdraw(173 * decimalScale, alice, alice);
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
 
         skip(500 days);
@@ -438,17 +439,17 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(9_101e6, alice);
+        cometWrapper.deposit(9_101 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(2_555e6, bob);
+        cometWrapper.deposit(2_555 * decimalScale, bob);
         vm.stopPrank();
 
         uint256 aliceAssets = cometWrapper.maxWithdraw(alice);
         uint256 bobCometBalance = comet.balanceOf(bob);
-        uint256 assetsToWithdraw = 333e6;
+        uint256 assetsToWithdraw = 333 * decimalScale;
         uint256 expectedAliceWrapperAssets = aliceAssets - assetsToWithdraw;
         uint256 expectedBobCometBalance = bobCometBalance + assetsToWithdraw;
 
@@ -472,12 +473,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(9_101e6, alice);
+        cometWrapper.deposit(9_101 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(2_555e6, bob);
+        cometWrapper.deposit(2_555 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
@@ -487,7 +488,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 bobAssets = cometWrapper.maxWithdraw(bob);
-        uint256 assetsToWithdraw = 987e6;
+        uint256 assetsToWithdraw = 987 * decimalScale;
         uint256 expectedBobWrapperAssets = bobAssets - assetsToWithdraw;
         uint256 expectedAliceCometBalance = aliceCometBalance + assetsToWithdraw;
 
@@ -511,16 +512,16 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, alice);
+        cometWrapper.mint(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, bob);
+        cometWrapper.mint(5_000 * decimalScale, bob);
         vm.stopPrank();
 
-        uint256 sharesToApprove = 2_700e6;
-        uint256 sharesToWithdraw = 2_500e6;
+        uint256 sharesToApprove = 2_700 * decimalScale;
+        uint256 sharesToWithdraw = 2_500 * decimalScale;
         uint256 assetsToWithdraw = cometWrapper.previewRedeem(sharesToWithdraw);
 
         vm.prank(alice);
@@ -530,7 +531,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         // Allowances should be updated when withdraw is done
         assertEq(cometWrapper.allowance(alice, bob), sharesToApprove);
         cometWrapper.withdraw(assetsToWithdraw, bob, alice);
-        assertEq(cometWrapper.balanceOf(alice), 5_000e6 - sharesToWithdraw);
+        assertEq(cometWrapper.balanceOf(alice), 5_000 * decimalScale - sharesToWithdraw);
 
         // Reverts if trying to withdraw again now that allowance is used up
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
@@ -554,21 +555,18 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(1_000e6, alice);
+        cometWrapper.deposit(1_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.prank(bob);
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.withdraw(900e6, bob, alice);
+        cometWrapper.withdraw(900 * decimalScale, bob, alice);
     }
 
     function test_mint(uint256 amount1, uint256 amount2) public {
         setUpAliceAndBobCometBalances();
 
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount2 <= 2**48);
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(amount1 > 100e6 && amount2 > 100e6);
+        (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);
@@ -614,22 +612,19 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
         vm.expectEmit(true, true, true, true);
-        emit Deposit(alice, bob, cometWrapper.previewMint(9_000e6), 9_000e6);
-        cometWrapper.mint(9_000e6, bob);
+        emit Deposit(alice, bob, cometWrapper.previewMint(9_000 * decimalScale), 9_000 * decimalScale);
+        cometWrapper.mint(9_000 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
-        assertEq(cometWrapper.balanceOf(bob), 9_000e6);
+        assertEq(cometWrapper.balanceOf(bob), 9_000 * decimalScale);
         assertEq(cometWrapper.maxRedeem(bob), cometWrapper.balanceOf(bob));
     }
 
     function test_redeem(uint256 amount1, uint256 amount2) public {
         setUpAliceAndBobCometBalances();
 
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount2 <= 2**48);
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(amount1 > 100e6 && amount2 > 100e6);
+        (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);
@@ -684,12 +679,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(8_098e6, alice);
+        cometWrapper.deposit(8_098 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(3_555e6, bob);
+        cometWrapper.deposit(3_555 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalSupply(), unsigned104(comet.userBasic(wrapperAddress).principal));
@@ -699,14 +694,14 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         uint256 aliceWrapperBalance = cometWrapper.balanceOf(alice);
         uint256 bobCometBalance = comet.balanceOf(bob);
-        uint256 sharesToRedeem = 777e6;
+        uint256 sharesToRedeem = 777 * decimalScale;
         uint256 expectedAliceWrapperBalance = aliceWrapperBalance - sharesToRedeem;
-        uint256 expectedBobCometBalance = bobCometBalance + cometWrapper.convertToAssets(sharesToRedeem);
+        uint256 expectedBobCometBalance = bobCometBalance + cometWrapper.previewRedeem(sharesToRedeem);
 
         // Alice redeems from herself to Bob
         vm.startPrank(alice);
         vm.expectEmit(true, true, true, true);
-        emit Withdraw(alice, bob, alice, cometWrapper.convertToAssets(sharesToRedeem), sharesToRedeem);
+        emit Withdraw(alice, bob, alice, cometWrapper.previewRedeem(sharesToRedeem), sharesToRedeem);
         cometWrapper.redeem(sharesToRedeem, bob, alice);
         vm.stopPrank();
 
@@ -723,12 +718,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(8_098e6, alice);
+        cometWrapper.deposit(8_098 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.deposit(3_555e6, bob);
+        cometWrapper.deposit(3_555 * decimalScale, bob);
         vm.stopPrank();
 
         assertEq(cometWrapper.totalSupply(), unsigned104(comet.userBasic(wrapperAddress).principal));
@@ -741,14 +736,14 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         uint256 aliceCometBalance = comet.balanceOf(alice);
         uint256 bobWrapperBalance = cometWrapper.balanceOf(bob);
-        uint256 sharesToRedeem = 1_322e6;
-        uint256 expectedAliceCometBalance = aliceCometBalance + cometWrapper.convertToAssets(sharesToRedeem);
+        uint256 sharesToRedeem = 1_322 * decimalScale;
+        uint256 expectedAliceCometBalance = aliceCometBalance + cometWrapper.previewRedeem(sharesToRedeem);
         uint256 expectedBobWrapperBalance = bobWrapperBalance - sharesToRedeem;
 
         // Alice redeems from Bob to herself
         vm.startPrank(alice);
         vm.expectEmit(true, true, true, true);
-        emit Withdraw(alice, alice, bob, cometWrapper.convertToAssets(sharesToRedeem), sharesToRedeem);
+        emit Withdraw(alice, alice, bob, cometWrapper.previewRedeem(sharesToRedeem), sharesToRedeem);
         cometWrapper.redeem(sharesToRedeem, alice, bob);
         vm.stopPrank();
 
@@ -765,16 +760,16 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, alice);
+        cometWrapper.mint(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, bob);
+        cometWrapper.mint(5_000 * decimalScale, bob);
         vm.stopPrank();
 
-        uint256 sharesToApprove = 2_700e6;
-        uint256 sharesToWithdraw = 2_500e6;
+        uint256 sharesToApprove = 2_700 * decimalScale;
+        uint256 sharesToWithdraw = 2_500 * decimalScale;
 
         vm.prank(alice);
         cometWrapper.approve(bob, sharesToApprove);
@@ -783,7 +778,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         // Allowances should be updated when redeem is done
         assertEq(cometWrapper.allowance(alice, bob), sharesToApprove);
         cometWrapper.redeem(sharesToWithdraw, bob, alice);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 5_000e6 - sharesToWithdraw, 1);
+        assertApproxEqAbs(cometWrapper.balanceOf(alice), 5_000 * decimalScale - sharesToWithdraw, 1);
 
         // Reverts if trying to redeem again now that allowance is used up
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
@@ -807,12 +802,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(1_000e6, alice);
+        cometWrapper.mint(1_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.prank(bob);
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.redeem(900e6, bob, alice);
+        cometWrapper.redeem(900 * decimalScale, bob, alice);
     }
 
     function test_revertsOnZeroShares() public {
@@ -834,13 +829,13 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(9_000e6, alice);
-        cometWrapper.transferFrom(alice, bob, 1_337e6);
+        cometWrapper.mint(9_000 * decimalScale, alice);
+        cometWrapper.transferFrom(alice, bob, 1_337 * decimalScale);
         vm.stopPrank();
 
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663e6, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337e6, 1);
-        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000e6, 1);
+        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663 * decimalScale, 1);
+        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337 * decimalScale, 1);
+        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000 * decimalScale, 1);
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
         skip(30 days);
@@ -848,22 +843,22 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         vm.startPrank(bob);
         comet.allow(wrapperAddress, true);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(bob, alice, 777e6);
-        cometWrapper.transfer(alice, 777e6);
+        emit Transfer(bob, alice, 777 * decimalScale);
+        cometWrapper.transfer(alice, 777 * decimalScale);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(bob, alice, 111e6);
-        cometWrapper.transfer(alice, 111e6);
+        emit Transfer(bob, alice, 111 * decimalScale);
+        cometWrapper.transfer(alice, 111 * decimalScale);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(bob, alice, 99e6);
-        cometWrapper.transfer(alice, 99e6);
+        emit Transfer(bob, alice, 99 * decimalScale);
+        cometWrapper.transfer(alice, 99 * decimalScale);
         vm.stopPrank();
 
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663e6 + 777e6 + 111e6 + 99e6, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337e6 - 777e6 - 111e6 - 99e6, 1);
+        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663 * decimalScale + 777 * decimalScale + 111 * decimalScale + 99 * decimalScale, 1);
+        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337 * decimalScale - 777 * decimalScale - 111 * decimalScale - 99 * decimalScale, 1);
 
         skip(30 days);
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
-        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000e6, 1);
+        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000 * decimalScale, 1);
         uint256 totalPrincipal = unsigned256(comet.userBasic(address(cometWrapper)).principal);
         assertEq(cometWrapper.totalSupply(), totalPrincipal);
     }
@@ -873,13 +868,13 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, alice);
+        cometWrapper.mint(5_000 * decimalScale, alice);
 
-        cometWrapper.transferFrom(alice, bob, 2_500e6);
+        cometWrapper.transferFrom(alice, bob, 2_500 * decimalScale);
         vm.stopPrank();
 
-        assertEq(cometWrapper.balanceOf(alice), 2_500e6);
-        assertEq(cometWrapper.balanceOf(bob), 2_500e6);
+        assertEq(cometWrapper.balanceOf(alice), 2_500 * decimalScale);
+        assertEq(cometWrapper.balanceOf(bob), 2_500 * decimalScale);
     }
 
     function test_transferFromUsesAllowances() public {
@@ -887,29 +882,29 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(5_000e6, alice);
+        cometWrapper.mint(5_000 * decimalScale, alice);
         vm.stopPrank();
 
         // Need approvals to transferFrom alice to bob
         vm.prank(bob);
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.transferFrom(alice, bob, 5_000e6);
+        cometWrapper.transferFrom(alice, bob, 5_000 * decimalScale);
 
         vm.prank(alice);
-        cometWrapper.approve(bob, 2_700e6);
+        cometWrapper.approve(bob, 2_700 * decimalScale);
 
         vm.startPrank(bob);
         // Allowances should be updated when transferFrom is done
-        assertEq(cometWrapper.allowance(alice, bob), 2_700e6);
-        cometWrapper.transferFrom(alice, bob, 2_500e6);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500e6, 1);
-        assertEq(cometWrapper.balanceOf(bob), 2_500e6);
+        assertEq(cometWrapper.allowance(alice, bob), 2_700 * decimalScale);
+        cometWrapper.transferFrom(alice, bob, 2_500 * decimalScale);
+        assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500 * decimalScale, 1);
+        assertEq(cometWrapper.balanceOf(bob), 2_500 * decimalScale);
 
         // Reverts if trying to transferFrom again now that allowance is used up
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.transferFrom(alice, bob, 2_500e6);
+        cometWrapper.transferFrom(alice, bob, 2_500 * decimalScale);
         vm.stopPrank();
-        assertEq(cometWrapper.allowance(alice, bob), 200e6);
+        assertEq(cometWrapper.allowance(alice, bob), 200 * decimalScale);
 
         // Infinite allowance does not decrease allowance
         vm.prank(bob);
@@ -917,7 +912,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(cometWrapper.allowance(bob, alice), type(uint256).max);
 
         vm.startPrank(alice);
-        cometWrapper.transferFrom(bob, alice, 1_000e6);
+        cometWrapper.transferFrom(bob, alice, 1_000 * decimalScale);
         assertEq(cometWrapper.allowance(bob, alice), type(uint256).max);
         vm.stopPrank();
     }
@@ -927,27 +922,27 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);
-        cometWrapper.mint(1_000e6, alice);
+        cometWrapper.mint(1_000 * decimalScale, alice);
         vm.stopPrank();
 
         vm.prank(bob);
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.transferFrom(alice, bob, 900e6);
+        cometWrapper.transferFrom(alice, bob, 900 * decimalScale);
 
         vm.prank(alice);
-        cometWrapper.approve(bob, 500e6);
+        cometWrapper.approve(bob, 500 * decimalScale);
 
         vm.startPrank(bob);
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.transferFrom(alice, bob, 800e6); // larger than allowance
+        cometWrapper.transferFrom(alice, bob, 800 * decimalScale); // larger than allowance
 
-        cometWrapper.transferFrom(alice, bob, 400e6); // less than allowance
+        cometWrapper.transferFrom(alice, bob, 400 * decimalScale); // less than allowance
 
         vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
-        cometWrapper.transferFrom(alice, bob, 200e6); // larger than remaining allowance
+        cometWrapper.transferFrom(alice, bob, 200 * decimalScale); // larger than remaining allowance
 
-        assertEq(cometWrapper.balanceOf(bob), 400e6);
-        assertEq(cometWrapper.allowance(alice, bob), 100e6);
+        assertEq(cometWrapper.balanceOf(bob), 400 * decimalScale);
+        assertEq(cometWrapper.allowance(alice, bob), 100 * decimalScale);
         vm.stopPrank();
     }
 }

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -94,7 +94,9 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         cometWrapper.deposit(5_000 * decimalScale, alice);
         vm.stopPrank();
 
+        // Rounds down underlying balance in favor of wrapper
         assertApproxEqAbs(cometWrapper.underlyingBalance(alice), 5_000 * decimalScale, 1);
+        assertLe(cometWrapper.underlyingBalance(alice), 5_000 * decimalScale);
         skip(14 days);
         assertGe(cometWrapper.underlyingBalance(alice), 5_000 * decimalScale);
     }
@@ -833,9 +835,9 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         cometWrapper.transferFrom(alice, bob, 1_337 * decimalScale);
         vm.stopPrank();
 
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663 * decimalScale, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337 * decimalScale, 1);
-        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000 * decimalScale, 1);
+        assertEq(cometWrapper.balanceOf(alice), 7_663 * decimalScale);
+        assertEq(cometWrapper.balanceOf(bob), 1_337 * decimalScale);
+        assertEq(cometWrapper.totalSupply(), 9_000 * decimalScale);
 
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
         skip(30 days);
@@ -853,12 +855,12 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         cometWrapper.transfer(alice, 99 * decimalScale);
         vm.stopPrank();
 
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 7_663 * decimalScale + 777 * decimalScale + 111 * decimalScale + 99 * decimalScale, 1);
-        assertApproxEqAbs(cometWrapper.balanceOf(bob), 1_337 * decimalScale - 777 * decimalScale - 111 * decimalScale - 99 * decimalScale, 1);
+        assertEq(cometWrapper.balanceOf(alice), (7_663 + 777 + 111 + 99) * decimalScale);
+        assertEq(cometWrapper.balanceOf(bob), (1_337 - 777 - 111 - 99) * decimalScale);
 
         skip(30 days);
         assertEq(cometWrapper.totalAssets(), comet.balanceOf(wrapperAddress));
-        assertApproxEqAbs(cometWrapper.totalSupply(), 9_000 * decimalScale, 1);
+        assertEq(cometWrapper.totalSupply(), 9_000 * decimalScale);
         uint256 totalPrincipal = unsigned256(comet.userBasic(address(cometWrapper)).principal);
         assertEq(cometWrapper.totalSupply(), totalPrincipal);
     }
@@ -897,7 +899,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         // Allowances should be updated when transferFrom is done
         assertEq(cometWrapper.allowance(alice, bob), 2_700 * decimalScale);
         cometWrapper.transferFrom(alice, bob, 2_500 * decimalScale);
-        assertApproxEqAbs(cometWrapper.balanceOf(alice), 2_500 * decimalScale, 1);
+        assertEq(cometWrapper.balanceOf(alice), 2_500 * decimalScale);
         assertEq(cometWrapper.balanceOf(bob), 2_500 * decimalScale);
 
         // Reverts if trying to transferFrom again now that allowance is used up

--- a/test/CometWrapper.t.sol
+++ b/test/CometWrapper.t.sol
@@ -11,10 +11,10 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
     event Approval(address indexed owner, address indexed spender, uint256 amount);
 
     function setUpAliceAndBobCometBalances() public {
-        deal(address(usdc), address(cusdcHolder), 20_000 * decimalScale);
-        vm.startPrank(cusdcHolder);
-        usdc.approve(address(comet), 20_000 * decimalScale);
-        comet.supply(address(usdc), 20_000 * decimalScale);
+        deal(address(underlyingToken), address(cometHolder), 20_000 * decimalScale);
+        vm.startPrank(cometHolder);
+        underlyingToken.approve(address(comet), 20_000 * decimalScale);
+        comet.supply(address(underlyingToken), 20_000 * decimalScale);
 
         comet.transfer(alice, 10_000 * decimalScale);
         assertGt(comet.balanceOf(alice), 9999 * decimalScale);
@@ -30,8 +30,8 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
         assertEq(address(cometWrapper.cometRewards()), address(cometRewards));
         assertEq(address(cometWrapper.asset()), address(comet));
         assertEq(cometWrapper.decimals(), comet.decimals());
-        assertEq(cometWrapper.name(), "Wrapped Comet USDC");
-        assertEq(cometWrapper.symbol(), "WcUSDCv3");
+        assertEq(cometWrapper.name(), "Wrapped Comet UNDERLYING");
+        assertEq(cometWrapper.symbol(), "WcUNDERLYINGv3");
         assertEq(cometWrapper.totalSupply(), 0);
         assertEq(cometWrapper.totalAssets(), 0);
     }
@@ -47,7 +47,7 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         // reverts on ERC20-only contract
         vm.expectRevert();
-        new CometWrapper(usdc, cometRewards, "Name", "Symbol");
+        new CometWrapper(underlyingToken, cometRewards, "Name", "Symbol");
     }
 
     function test_constructor_revertsOnInvalidCometRewards() public {
@@ -321,10 +321,10 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(bob, amount2);
 
         vm.startPrank(alice);
@@ -570,10 +570,10 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(bob, amount2);
 
         uint256 aliceMintAmount = amount1 / 2;
@@ -628,10 +628,10 @@ abstract contract CometWrapperTest is CoreTest, CometMath {
 
         (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(bob, amount2);
 
         vm.startPrank(alice);

--- a/test/CometWrapperInvariant.t.sol
+++ b/test/CometWrapperInvariant.t.sol
@@ -10,10 +10,7 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     // - sum of all underlyingBalances of accounts <= totalAssets
     // - sum of user balances == cometWrapper's principal in comet
     function test_contractBalanceInvariants(uint256 amount1, uint256 amount2) public {
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount2 <= 2**48);
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(amount1 > 100e6 && amount2 > 100e6);
+        (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);
@@ -82,9 +79,7 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     // Invariants:
     // - on redeem, decrease in wrapper's Comet principal == burnt user shares == change in total supply
     function test_redeemInvariants(uint256 amount1) public {
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount1 > 1000e6);
-        vm.assume(amount1 < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
+        amount1 = setUpFuzzTestAssumptions(amount1);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);
@@ -136,10 +131,7 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     // - transfers must not change totalSupply
     // - transfers must not change totalAssets
     function test_transferInvariants(uint256 amount1, uint256 amount2) public {
-        vm.assume(amount1 <= 2**48);
-        vm.assume(amount2 <= 2**48);
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder));
-        vm.assume(amount1 > 1000e6 && amount2 > 1000e6);
+        (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
         vm.prank(cusdcHolder);
         comet.transfer(alice, amount1);

--- a/test/CometWrapperInvariant.t.sol
+++ b/test/CometWrapperInvariant.t.sol
@@ -12,9 +12,9 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     function test_contractBalanceInvariants(uint256 amount1, uint256 amount2) public {
         (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(bob, amount2);
 
         uint256 aliceBalance = comet.balanceOf(alice);
@@ -81,7 +81,7 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     function test_redeemInvariants(uint256 amount1) public {
         amount1 = setUpFuzzTestAssumptions(amount1);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
 
         skip(30000 days);
@@ -133,9 +133,9 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
     function test_transferInvariants(uint256 amount1, uint256 amount2) public {
         (amount1, amount2) = setUpFuzzTestAssumptions(amount1, amount2);
 
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, amount1);
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(bob, amount2);
 
         vm.startPrank(alice);

--- a/test/CoreTest.sol
+++ b/test/CoreTest.sol
@@ -13,23 +13,23 @@ abstract contract CoreTest is Test {
     function CONFIGURATOR_ADDRESS() external virtual returns (address);
     function PROXY_ADMIN_ADDRESS() external virtual returns (address);
     function COMP_ADDRESS() external virtual returns (address);
-    function USDC_ADDRESS() external virtual returns (address);
-    function USDC_HOLDER() external virtual returns (address);
-    function CUSDC_HOLDER() external virtual returns (address);
+    function UNDERLYING_TOKEN_ADDRESS() external virtual returns (address);
+    function UNDERLYING_TOKEN_HOLDER() external virtual returns (address);
+    function COMET_HOLDER() external virtual returns (address);
 
     address public cometAddress;
     address public rewardAddress;
     address public configuratorAddress;
     address public proxyAdminAddress;
     address public compAddress;
-    address public usdcHolder;
-    address public usdcAddress;
-    address public cusdcHolder;
+    address public underlyingTokenHolder;
+    address public underlyingTokenAddress;
+    address public cometHolder;
 
     CometWrapper public cometWrapper;
     CometInterface public comet;
     ICometRewards public cometRewards;
-    ERC20 public usdc;
+    ERC20 public underlyingToken;
     ERC20 public comp;
     address public wrapperAddress;
     uint256 public decimalScale;
@@ -47,22 +47,22 @@ abstract contract CoreTest is Test {
         configuratorAddress = this.CONFIGURATOR_ADDRESS();
         proxyAdminAddress = this.PROXY_ADMIN_ADDRESS();
         compAddress = this.COMP_ADDRESS();
-        usdcAddress = this.USDC_ADDRESS();
-        usdcHolder = this.USDC_HOLDER();
-        cusdcHolder = this.CUSDC_HOLDER();
+        underlyingTokenAddress = this.UNDERLYING_TOKEN_ADDRESS();
+        underlyingTokenHolder = this.UNDERLYING_TOKEN_HOLDER();
+        cometHolder = this.COMET_HOLDER();
 
-        usdc = ERC20(this.usdcAddress());
-        comp = ERC20(this.compAddress());
-        comet = CometInterface(this.cometAddress());
-        cometRewards = ICometRewards(this.rewardAddress());
+        underlyingToken = ERC20(underlyingTokenAddress);
+        comp = ERC20(compAddress);
+        comet = CometInterface(cometAddress);
+        cometRewards = ICometRewards(rewardAddress);
         cometWrapper =
-            new CometWrapper(ERC20(this.cometAddress()), ICometRewards(this.rewardAddress()), "Wrapped Comet USDC", "WcUSDCv3");
+            new CometWrapper(ERC20(cometAddress), ICometRewards(rewardAddress), "Wrapped Comet UNDERLYING", "WcUNDERLYINGv3");
         wrapperAddress = address(cometWrapper);
-        decimalScale = 10 ** usdc.decimals();
+        decimalScale = 10 ** underlyingToken.decimals();
     }
 
     function setUpFuzzTestAssumptions(uint256 amount) public view returns (uint256) {
-        string memory underlyingSymbol = usdc.symbol();
+        string memory underlyingSymbol = underlyingToken.symbol();
         uint256 minBorrow;
         if (isEqual(underlyingSymbol, "USDC") || isEqual(underlyingSymbol, "USDbC")) {
             minBorrow = 100 * decimalScale;
@@ -72,12 +72,12 @@ abstract contract CoreTest is Test {
             revert("Unsupported underlying asset");
         }
 
-        amount = bound(amount, minBorrow, comet.balanceOf(cusdcHolder) - minBorrow);
+        amount = bound(amount, minBorrow, comet.balanceOf(cometHolder) - minBorrow);
         return amount;
     }
 
     function setUpFuzzTestAssumptions(uint256 amount1, uint256 amount2) public view returns (uint256, uint256) {
-        string memory underlyingSymbol = usdc.symbol();
+        string memory underlyingSymbol = underlyingToken.symbol();
         uint256 minBorrow;
         if (isEqual(underlyingSymbol, "USDC") || isEqual(underlyingSymbol, "USDbC")) {
             minBorrow = 100 * decimalScale;
@@ -91,7 +91,7 @@ abstract contract CoreTest is Test {
             revert("Unsupported underlying asset");
         }
 
-        vm.assume(amount1 + amount2 < comet.balanceOf(cusdcHolder) - minBorrow); // to account for borrowMin
+        vm.assume(amount1 + amount2 < comet.balanceOf(cometHolder) - minBorrow); // to account for borrowMin
         return (amount1, amount2);
     }
 

--- a/test/MainnetUSDCTest.t.sol
+++ b/test/MainnetUSDCTest.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
+import { CometWrapperTest } from "./CometWrapper.t.sol";
+import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
+import { RewardsTest } from "./Rewards.t.sol";
+
+contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+    string public override NETWORK = "mainnet";
+    uint256 public override FORK_BLOCK_NUMBER = 16617900;
+
+    address public override COMET_ADDRESS = 0xc3d688B66703497DAA19211EEdff47f25384cdc3;
+    address public override REWARD_ADDRESS = 0x1B0e765F6224C21223AeA2af16c1C46E38885a40;
+    address public override CONFIGURATOR_ADDRESS = 0x316f9708bB98af7dA9c68C1C3b5e79039cD336E3;
+    address public override PROXY_ADMIN_ADDRESS = 0x1EC63B5883C3481134FD50D5DAebc83Ecd2E8779;
+    address public override COMP_ADDRESS = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+    address public override USDC_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public override USDC_HOLDER = 0x0A59649758aa4d66E25f08Dd01271e891fe52199;
+    address public override CUSDC_HOLDER = 0x638e9ad05DBd35B1c19dF3a4EAa0642A3B90A2AD;
+}

--- a/test/MainnetUSDCTest.t.sol
+++ b/test/MainnetUSDCTest.t.sol
@@ -16,7 +16,7 @@ contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, Rewards
     address public override CONFIGURATOR_ADDRESS = 0x316f9708bB98af7dA9c68C1C3b5e79039cD336E3;
     address public override PROXY_ADMIN_ADDRESS = 0x1EC63B5883C3481134FD50D5DAebc83Ecd2E8779;
     address public override COMP_ADDRESS = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
-    address public override USDC_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address public override USDC_HOLDER = 0x0A59649758aa4d66E25f08Dd01271e891fe52199;
-    address public override CUSDC_HOLDER = 0x638e9ad05DBd35B1c19dF3a4EAa0642A3B90A2AD;
+    address public override UNDERLYING_TOKEN_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public override UNDERLYING_TOKEN_HOLDER = 0x0A59649758aa4d66E25f08Dd01271e891fe52199;
+    address public override COMET_HOLDER = 0x638e9ad05DBd35B1c19dF3a4EAa0642A3B90A2AD;
 }

--- a/test/MainnetWETHTest.t.sol
+++ b/test/MainnetWETHTest.t.sol
@@ -7,16 +7,16 @@ import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract MainnetTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
     string public override NETWORK = "mainnet";
-    uint256 public override FORK_BLOCK_NUMBER = 16617900;
+    uint256 public override FORK_BLOCK_NUMBER = 18285773;
 
-    address public override COMET_ADDRESS = 0xc3d688B66703497DAA19211EEdff47f25384cdc3;
+    address public override COMET_ADDRESS = 0xA17581A9E3356d9A858b789D68B4d866e593aE94;
     address public override REWARD_ADDRESS = 0x1B0e765F6224C21223AeA2af16c1C46E38885a40;
     address public override CONFIGURATOR_ADDRESS = 0x316f9708bB98af7dA9c68C1C3b5e79039cD336E3;
     address public override PROXY_ADMIN_ADDRESS = 0x1EC63B5883C3481134FD50D5DAebc83Ecd2E8779;
     address public override COMP_ADDRESS = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
-    address public override USDC_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address public override USDC_HOLDER = 0x0A59649758aa4d66E25f08Dd01271e891fe52199;
-    address public override CUSDC_HOLDER = 0x638e9ad05DBd35B1c19dF3a4EAa0642A3B90A2AD;
+    address public override USDC_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH
+    address public override USDC_HOLDER = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E; // WETH
+    address public override CUSDC_HOLDER = 0x10D88638Be3c26f3a47d861B8b5641508501035d; // cWETHv3
 }

--- a/test/MainnetWETHTest.t.sol
+++ b/test/MainnetWETHTest.t.sol
@@ -16,7 +16,7 @@ contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, Rewards
     address public override CONFIGURATOR_ADDRESS = 0x316f9708bB98af7dA9c68C1C3b5e79039cD336E3;
     address public override PROXY_ADMIN_ADDRESS = 0x1EC63B5883C3481134FD50D5DAebc83Ecd2E8779;
     address public override COMP_ADDRESS = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
-    address public override USDC_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH
-    address public override USDC_HOLDER = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E; // WETH
-    address public override CUSDC_HOLDER = 0x10D88638Be3c26f3a47d861B8b5641508501035d; // cWETHv3
+    address public override UNDERLYING_TOKEN_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH
+    address public override UNDERLYING_TOKEN_HOLDER = 0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E; // WETH
+    address public override COMET_HOLDER = 0x10D88638Be3c26f3a47d861B8b5641508501035d; // cWETHv3
 }

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -18,7 +18,7 @@ abstract contract RewardsTest is CoreTest {
         if (bobAmount % 2 != 0) bobAmount -= 1;
 
         // Alice and Bob have same amount of funds in both CometWrapper and Comet
-        vm.startPrank(cusdcHolder);
+        vm.startPrank(cometHolder);
         comet.transfer(alice, aliceAmount);
         comet.transfer(bob, bobAmount);
         vm.stopPrank();
@@ -77,7 +77,7 @@ abstract contract RewardsTest is CoreTest {
         vm.etch(newRewardsAddr, code);
 
         CometWrapper newCometWrapper =
-            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "Net Comet Wrapper", "NewWcUSDCv3");
+            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "New Comet Wrapper", "NewWcUNDERLYINGv3");
 
         vm.expectRevert(CometWrapper.UninitializedReward.selector);
         newCometWrapper.getRewardOwed(alice);
@@ -96,7 +96,7 @@ abstract contract RewardsTest is CoreTest {
         if (aliceAmount % 2 != 0) aliceAmount -= 1;
         if (bobAmount % 2 != 0) bobAmount -= 1;
 
-        vm.startPrank(cusdcHolder);
+        vm.startPrank(cometHolder);
         comet.transfer(alice, aliceAmount);
         comet.transfer(bob, bobAmount);
         vm.stopPrank();
@@ -159,7 +159,7 @@ abstract contract RewardsTest is CoreTest {
         vm.etch(newRewardsAddr, code);
 
         CometWrapper newCometWrapper =
-            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "New Comet Wrapper", "NewWcUSDCv3");
+            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "New Comet Wrapper", "NewWcUNDERLYINGv3");
 
         vm.prank(alice);
         vm.expectRevert(CometWrapper.UninitializedReward.selector);
@@ -176,7 +176,7 @@ abstract contract RewardsTest is CoreTest {
         // Make amount an even number so it can be divided equally by 2
         if (aliceAmount % 2 != 0) aliceAmount -= 1;
 
-        vm.startPrank(cusdcHolder);
+        vm.startPrank(cometHolder);
         comet.transfer(alice, aliceAmount);
         vm.stopPrank();
 
@@ -215,7 +215,7 @@ abstract contract RewardsTest is CoreTest {
         vm.prank(alice);
         cometWrapper.transfer(bob, 5_000e6);
 
-        // Alice should have 30 days worth of accrued rewards for her 10K WcUSDC
+        // Alice should have 30 days worth of accrued rewards for her 10K WcUNDERLYING
         assertEq(cometWrapper.getRewardOwed(alice), cometRewards.getRewardOwed(cometAddress, alice).owed);
         // Bob should have no rewards accrued yet since his balance prior to the transfer was 0
         assertEq(cometWrapper.getRewardOwed(bob), 0);
@@ -228,7 +228,7 @@ abstract contract RewardsTest is CoreTest {
         vm.prank(alice);
         cometWrapper.redeem(5_000e6, alice, alice);
 
-        // Alice should have 30 days worth of accrued rewards for her 10K WcUSDC and not for 5K WcUSDC
+        // Alice should have 30 days worth of accrued rewards for her 10K WcUNDERLYING and not for 5K WcUNDERLYING
         assertEq(cometWrapper.getRewardOwed(alice), cometRewards.getRewardOwed(cometAddress, alice).owed);
 
         vm.revertTo(snapshot);
@@ -239,7 +239,7 @@ abstract contract RewardsTest is CoreTest {
         vm.prank(alice);
         cometWrapper.withdraw(5_000e6, alice, alice);
 
-        // Alice should have 30 days worth of accrued rewards for her 10K WcUSDC and not for 5K WcUSDC
+        // Alice should have 30 days worth of accrued rewards for her 10K WcUNDERLYING and not for 5K WcUNDERLYING
         assertEq(cometWrapper.getRewardOwed(alice), cometRewards.getRewardOwed(cometAddress, alice).owed);
 
         vm.revertTo(snapshot);
@@ -250,7 +250,7 @@ abstract contract RewardsTest is CoreTest {
         vm.prank(alice);
         cometWrapper.mint(5_000e6, alice);
 
-        // Alice should have 30 days worth of accrued rewards for her 10K WcUSDC and not for 5K WcUSDC
+        // Alice should have 30 days worth of accrued rewards for her 10K WcUNDERLYING and not for 5K WcUNDERLYING
         assertEq(cometWrapper.getRewardOwed(alice), cometRewards.getRewardOwed(cometAddress, alice).owed);
 
         vm.revertTo(snapshot);
@@ -261,12 +261,12 @@ abstract contract RewardsTest is CoreTest {
         vm.prank(alice);
         cometWrapper.deposit(5_000e6, alice);
 
-        // Alice should have 30 days worth of accrued rewards for her 10K WcUSDC and not for 5K WcUSDC
+        // Alice should have 30 days worth of accrued rewards for her 10K WcUNDERLYING and not for 5K WcUNDERLYING
         assertEq(cometWrapper.getRewardOwed(alice), cometRewards.getRewardOwed(cometAddress, alice).owed);
     }
 
     function setupAliceBalance() internal {
-        vm.prank(cusdcHolder);
+        vm.prank(cometHolder);
         comet.transfer(alice, 20_000e6);
         vm.startPrank(alice);
         comet.allow(wrapperAddress, true);

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -9,10 +9,7 @@ abstract contract RewardsTest is CoreTest {
     function test_getRewardOwed(uint256 aliceAmount, uint256 bobAmount) public {
         /* ===== Setup ===== */
 
-        vm.assume(aliceAmount <= 2**48);
-        vm.assume(bobAmount <= 2**48);
-        vm.assume(aliceAmount + bobAmount < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(aliceAmount >= 2e6 && bobAmount >= 2e6);
+        (aliceAmount, bobAmount) = setUpFuzzTestAssumptions(aliceAmount, bobAmount);
 
         enableRewardsAccrual();
 
@@ -89,10 +86,7 @@ abstract contract RewardsTest is CoreTest {
     function test_claimTo(uint256 aliceAmount, uint256 bobAmount) public {
         /* ===== Setup ===== */
 
-        vm.assume(aliceAmount <= 2**48);
-        vm.assume(bobAmount <= 2**48);
-        vm.assume(aliceAmount + bobAmount < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(aliceAmount >= 2e6 && bobAmount >= 2e6);
+        (aliceAmount, bobAmount) = setUpFuzzTestAssumptions(aliceAmount, bobAmount);
 
         enableRewardsAccrual();
         // Make sure CometRewards has ample COMP to claim
@@ -165,7 +159,7 @@ abstract contract RewardsTest is CoreTest {
         vm.etch(newRewardsAddr, code);
 
         CometWrapper newCometWrapper =
-            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "Net Comet Wrapper", "NewWcUSDCv3");
+            new CometWrapper(ERC20(cometAddress), ICometRewards(newRewardsAddr), "New Comet Wrapper", "NewWcUSDCv3");
 
         vm.prank(alice);
         vm.expectRevert(CometWrapper.UninitializedReward.selector);
@@ -175,9 +169,7 @@ abstract contract RewardsTest is CoreTest {
     function test_accrueRewards(uint256 aliceAmount) public {
         /* ===== Setup ===== */
 
-        vm.assume(aliceAmount <= 2**48);
-        vm.assume(aliceAmount < comet.balanceOf(cusdcHolder) - 100e6); // to account for borrowMin
-        vm.assume(aliceAmount >= 2e6);
+        aliceAmount = setUpFuzzTestAssumptions(aliceAmount);
 
         enableRewardsAccrual();
 


### PR DESCRIPTION
We generalize the tests even more to work with any decimals that Comet and the underlying asset may have. We also introduce tests for cWETHv3 on mainnet.