### PR TITLE
Add encumber functionality

### DIFF
--- a/src/CometWrapper.sol
+++ b/src/CometWrapper.sol
@@ -209,10 +209,9 @@ contract CometWrapper is ERC4626, IERC7246, CometHelpers {
         if (amount > encumberedToTaker)  {
             uint256 excessAmount = amount - encumberedToTaker;
 
-            // WARNING: this check needs to happen BEFORE _releaseEncumbrance,
-            // otherwise the released encumbrance will increase
-            // availableBalanceOf(from), allowing dst to transfer tokens that
-            // are encumbered to someone else
+            // WARNING: this check needs to happen BEFORE releaseEncumbranceInternal,
+            // otherwise the released encumbrance will increase availableBalanceOf(from),
+            // allowing msg.sender to transfer tokens that are encumbered to someone else
 
             if (availableBalanceOf(from) < excessAmount) revert InsufficientAvailableBalance();
 

--- a/src/CometWrapper.sol
+++ b/src/CometWrapper.sol
@@ -145,6 +145,7 @@ contract CometWrapper is ERC4626, IERC7246, CometHelpers {
         if (shares == 0) revert ZeroShares();
 
         if (msg.sender != owner) {
+            // TODO: spend encumbrance, then allowance
             spendAllowanceInternal(owner, msg.sender, shares);
         }
 
@@ -167,6 +168,7 @@ contract CometWrapper is ERC4626, IERC7246, CometHelpers {
     function redeem(uint256 shares, address receiver, address owner) public override returns (uint256) {
         if (shares == 0) revert ZeroShares();
         if (msg.sender != owner) {
+            // TODO: spend encumbrance, then allowance
             spendAllowanceInternal(owner, msg.sender, shares);
         }
 

--- a/src/vendor/CometExtInterface.sol
+++ b/src/vendor/CometExtInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 struct TotalsBasic {

--- a/src/vendor/CometInterface.sol
+++ b/src/vendor/CometInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 import "./CometMainInterface.sol";

--- a/src/vendor/CometMainInterface.sol
+++ b/src/vendor/CometMainInterface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 struct AssetInfo {

--- a/src/vendor/CometMath.sol
+++ b/src/vendor/CometMath.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 /**

--- a/src/vendor/ICometRewards.sol
+++ b/src/vendor/ICometRewards.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: ISC
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
 interface ICometRewards {

--- a/src/vendor/IERC7246.sol
+++ b/src/vendor/IERC7246.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+pragma solidity ^0.8.21;
+
+/**
+ * @dev Interface of the ERC7246 standard.
+ */
+interface IERC7246 {
+    /**
+     * @dev Emitted when `amount` tokens are encumbered from `owner` to `taker`.
+     */
+    event Encumber(address indexed owner, address indexed taker, uint256 amount);
+
+    /**
+     * @dev Emitted when the encumbrance of an `owner` to a `taker` is reduced
+     * by `amount`.
+     */
+    event Release(address indexed owner, address indexed taker, uint256 amount);
+
+    /**
+     * @dev Returns the total amount of tokens owned by `owner` that are
+     * currently encumbered.  MUST never exceed `balanceOf(owner)`
+     *
+     * Any function which would reduce balanceOf(owner) below
+     * encumberedBalanceOf(owner) MUST revert
+     */
+    function encumberedBalanceOf(address owner) external view returns (uint256);
+
+    /**
+     * @dev Returns the number of tokens that `owner` has encumbered to `taker`.
+     *
+     * This value increases when {encumber} or {encumberFrom} are called by the
+     * `owner` or by another permitted account.
+     * This value decreases when {release} and {transferFrom} are called by
+     * `taker`.
+     */
+    function encumbrances(address owner, address taker) external view returns (uint256);
+
+    /**
+     * @dev Increases the amount of tokens that the caller has encumbered to
+     * `taker` by `amount`.
+     * Grants to `taker` a guaranteed right to transfer `amount` from the
+     * caller's balance by using `transferFrom`.
+     *
+     * MUST revert if caller does not have `amount` tokens available (e.g. if
+     * `balanceOf(caller) - encumbrances(caller) < amount`).
+     *
+     * Emits an {Encumber} event.
+     */
+    function encumber(address taker, uint256 amount) external;
+
+    /**
+     * @dev Increases the amount of tokens that `owner` has encumbered to
+     * `taker` by `amount`.
+     * Grants to `taker` a guaranteed right to transfer `amount` from `owner`
+     * using transferFrom
+     *
+     * The function SHOULD revert unless the owner account has deliberately
+     * authorized the sender of the message via some mechanism.
+     *
+     * MUST revert if `owner` does not have `amount` tokens available (e.g. if
+     * `balanceOf(owner) - encumbrances(owner) < amount`).
+     *
+     * Emits an {Encumber} event.
+     */
+    function encumberFrom(address owner, address taker, uint256 amount) external;
+
+    /**
+     * @dev Reduces amount of tokens encumbered from `owner` to caller by
+     * `amount`.
+     *
+     * Emits a {Release} event.
+     */
+    function release(address owner, uint256 amount) external;
+
+    /**
+     * @dev Convenience function for reading the unencumbered balance of an address.
+     * Trivially implemented as `balanceOf(owner) - encumberedBalanceOf(owner)`
+     */
+    function availableBalanceOf(address owner) external view returns (uint256);
+}

--- a/src/vendor/IERC7246.sol
+++ b/src/vendor/IERC7246.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: BSD-3-Clause
-
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 /**

--- a/test/BaseUSDbCTest.t.sol
+++ b/test/BaseUSDbCTest.t.sol
@@ -5,9 +5,10 @@ import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
+import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
     string public override NETWORK = "base";
     uint256 public override FORK_BLOCK_NUMBER = 4791144;
 

--- a/test/CometWrapperInvariant.t.sol
+++ b/test/CometWrapperInvariant.t.sol
@@ -154,25 +154,25 @@ abstract contract CometWrapperInvariantTest is CoreTest, CometMath {
 
         for (uint256 i; i < 5; i++) {
             vm.startPrank(alice);
-            cometWrapper.transferFrom(alice, bob, cometWrapper.balanceOf(alice)/5);
+            cometWrapper.transfer(bob, cometWrapper.balanceOf(alice)/5);
             assertEq(cometWrapper.totalAssets(), totalAssets);
             assertEq(cometWrapper.totalSupply(), totalSupply);
             vm.stopPrank();
 
             vm.startPrank(bob);
-            cometWrapper.transferFrom(bob, alice, cometWrapper.balanceOf(bob)/5);
+            cometWrapper.transfer(alice, cometWrapper.balanceOf(bob)/5);
             assertEq(cometWrapper.totalAssets(), totalAssets);
             assertEq(cometWrapper.totalSupply(), totalSupply);
             vm.stopPrank();
 
             vm.startPrank(bob);
-            cometWrapper.transferFrom(bob, alice, cometWrapper.balanceOf(bob)/5);
+            cometWrapper.transfer(alice, cometWrapper.balanceOf(bob)/5);
             assertEq(cometWrapper.totalAssets(), totalAssets);
             assertEq(cometWrapper.totalSupply(), totalSupply);
             vm.stopPrank();
 
             vm.startPrank(alice);
-            cometWrapper.transferFrom(alice, bob, cometWrapper.balanceOf(alice)/5);
+            cometWrapper.transfer(bob, cometWrapper.balanceOf(alice)/5);
             assertEq(cometWrapper.totalAssets(), totalAssets);
             assertEq(cometWrapper.totalSupply(), totalSupply);
             vm.stopPrank();

--- a/test/CoreTest.sol
+++ b/test/CoreTest.sol
@@ -36,10 +36,12 @@ abstract contract CoreTest is Test {
 
     address alice = address(0xABCD);
     address bob = address(0xDCBA);
+    address charlie = address(0xCDAB);
 
     function setUp() public virtual {
         vm.label(alice, "alice");
         vm.label(bob, "bob");
+        vm.label(charlie, "charlie");
         vm.createSelectFork(vm.rpcUrl(this.NETWORK()), this.FORK_BLOCK_NUMBER());
 
         cometAddress = this.COMET_ADDRESS();

--- a/test/Encumber.t.sol
+++ b/test/Encumber.t.sol
@@ -1,0 +1,321 @@
+pragma solidity ^0.8.21;
+
+import { CoreTest, CometHelpers, CometWrapper, ERC20, ICometRewards } from "./CoreTest.sol";
+
+abstract contract EncumberTest is CoreTest {
+    event Encumber(address indexed owner, address indexed taker, uint amount);
+    event Release(address indexed owner, address indexed taker, uint amount);
+
+    function test_availableBalanceOf() public {
+        vm.startPrank(alice);
+
+        // availableBalanceOf is 0 by default
+        assertEq(cometWrapper.availableBalanceOf(alice), 0);
+
+        // reflects balance when there are no encumbrances
+        deal(address(cometWrapper), alice, 100e18);
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 100e18);
+
+        // is reduced by encumbrances
+        cometWrapper.encumber(bob, 20e18);
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 80e18);
+
+        // is reduced by transfers
+        cometWrapper.transfer(bob, 20e18);
+        assertEq(cometWrapper.balanceOf(alice), 80e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 60e18);
+
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+
+        // is NOT reduced by transferFrom (from an encumbered address)
+        cometWrapper.transferFrom(alice, charlie, 10e18);
+        assertEq(cometWrapper.balanceOf(alice), 70e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 60e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 10e18);
+        assertEq(cometWrapper.balanceOf(charlie), 10e18);
+
+        // is increased by a release
+        cometWrapper.release(alice, 5e18);
+        assertEq(cometWrapper.balanceOf(alice), 70e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 65e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 5e18);
+
+        vm.stopPrank();
+    }
+
+    function test_transfer_revertsOnInsufficentAvailableBalance() public {
+        deal(address(cometWrapper), alice, 100e18);
+        vm.startPrank(alice);
+
+        // alice encumbers half her balance to bob
+        cometWrapper.encumber(bob, 50e18);
+
+        // alice attempts to transfer her entire balance
+        vm.expectRevert(CometWrapper.InsufficientAvailableBalance.selector);
+        cometWrapper.transfer(charlie, 100e18);
+
+        vm.stopPrank();
+    }
+
+    function test_encumber_revertsOnInsufficientAvailableBalance() public {
+        deal(address(cometWrapper), alice, 100e18);
+        vm.startPrank(alice);
+
+        // alice encumbers half her balance to bob
+        cometWrapper.encumber(bob, 50e18);
+
+        // alice attempts to encumber more than her remaining available balance
+        vm.expectRevert(CometWrapper.InsufficientAvailableBalance.selector);
+        cometWrapper.encumber(charlie, 60e18);
+
+        vm.stopPrank();
+    }
+
+    function test_encumber() public {
+        deal(address(cometWrapper), alice, 100e18);
+        vm.startPrank(alice);
+
+        // emits Encumber event
+        vm.expectEmit(true, true, true, true);
+        emit Encumber(alice, bob, 60e18);
+
+        // alice encumbers some of her balance to bob
+        cometWrapper.encumber(bob, 60e18);
+
+        // balance is unchanged
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        // available balance is reduced
+        assertEq(cometWrapper.availableBalanceOf(alice), 40e18);
+
+        // creates encumbrance for taker
+        assertEq(cometWrapper.encumbrances(alice, bob), 60e18);
+
+        // updates encumbered balance of owner
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 60e18);
+    }
+
+    function test_transferFromWithSufficientEncumbrance() public {
+        deal(address(cometWrapper), alice, 100e18);
+        vm.prank(alice);
+
+        // alice encumbers some of her balance to bob
+        cometWrapper.encumber(bob, 60e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 40e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 60e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 60e18);
+        assertEq(cometWrapper.balanceOf(charlie), 0);
+
+        // bob calls transfers from alice to charlie
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit Release(alice, bob, 40e18);
+        cometWrapper.transferFrom(alice, charlie, 40e18);
+
+        // alice balance is reduced
+        assertEq(cometWrapper.balanceOf(alice), 60e18);
+        // alice encumbrance to bob is reduced
+        assertEq(cometWrapper.availableBalanceOf(alice), 40e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 20e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 20e18);
+        // transfer is completed
+        assertEq(cometWrapper.balanceOf(charlie), 40e18);
+    }
+
+    function test_transferFromUsesEncumbranceAndAllowance() public {
+        deal(address(cometWrapper), alice, 100e18);
+        vm.startPrank(alice);
+
+        // alice encumbers some of her balance to bob
+        cometWrapper.encumber(bob, 20e18);
+
+        // she also grants him an approval
+        cometWrapper.approve(bob, 30e18);
+
+        vm.stopPrank();
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 80e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 20e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 20e18);
+        assertEq(cometWrapper.allowance(alice, bob), 30e18);
+        assertEq(cometWrapper.balanceOf(charlie), 0);
+
+        // bob calls transfers from alice to charlie
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit Release(alice, bob, 20e18);
+        cometWrapper.transferFrom(alice, charlie, 40e18);
+
+        // alice balance is reduced
+        assertEq(cometWrapper.balanceOf(alice), 60e18);
+
+        // her encumbrance to bob has been fully spent
+        assertEq(cometWrapper.availableBalanceOf(alice), 60e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // her allowance to bob has been partially spent
+        assertEq(cometWrapper.allowance(alice, bob), 10e18);
+
+        // the dst receives the transfer
+        assertEq(cometWrapper.balanceOf(charlie), 40e18);
+    }
+
+    function test_transferFrom_revertsIfSpendingTokensEncumberedToOthers() public {
+        deal(address(cometWrapper), alice, 200e18);
+        vm.startPrank(alice);
+
+        // alice encumbers some of her balance to bob
+        cometWrapper.encumber(bob, 50e18);
+
+        // she also grants him an approval
+        cometWrapper.approve(bob, type(uint256).max);
+
+        // alice encumbers the remainder of her balance to charlie
+        cometWrapper.encumber(charlie, 150e18);
+
+        vm.stopPrank();
+
+        assertEq(cometWrapper.balanceOf(alice), 200e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 200e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 50e18);
+        assertEq(cometWrapper.encumbrances(alice, charlie), 150e18);
+        assertEq(cometWrapper.allowance(alice, bob), type(uint256).max);
+
+        // bob calls transfers from alice, attempting to transfer his encumbered
+        // tokens and also transfer tokens encumbered to charlie
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InsufficientAvailableBalance.selector);
+        cometWrapper.transferFrom(alice, bob, 100e18);
+    }
+
+    function test_transferFrom_revertsIfInsufficientAllowance() public {
+        deal(address(cometWrapper), alice, 100e18);
+
+        vm.startPrank(alice);
+
+        // alice encumbers some of her balance to bob
+        cometWrapper.encumber(bob, 10e18);
+
+        // she also grants him an approval
+        cometWrapper.approve(bob, 20e18);
+
+        vm.stopPrank();
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 90e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 10e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 10e18);
+        assertEq(cometWrapper.allowance(alice, bob), 20e18);
+        assertEq(cometWrapper.balanceOf(charlie), 0);
+
+        // bob tries to transfer more than his encumbered and allowed balances
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
+        cometWrapper.transferFrom(alice, charlie, 40e18);
+    }
+
+    function test_encumberFrom_revertsOnInsufficientAllowance() public {
+        deal(address(cometWrapper), alice, 100e18);
+
+        // alice grants bob an approval
+        vm.prank(alice);
+        cometWrapper.approve(bob, 50e18);
+
+        // but bob tries to encumber more than his allowance
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InsufficientAllowance.selector);
+        cometWrapper.encumberFrom(alice, charlie, 60e18);
+    }
+
+    function test_encumberFrom() public {
+        deal(address(cometWrapper), alice, 100e18);
+
+        // alice grants bob an approval
+        vm.prank(alice);
+        cometWrapper.approve(bob, 100e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 100e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0e18);
+        assertEq(cometWrapper.allowance(alice, bob), 100e18);
+        assertEq(cometWrapper.balanceOf(charlie), 0);
+
+        // but bob tries to encumber more than his allowance
+        vm.prank(bob);
+        // emits an Encumber event
+        vm.expectEmit(true, true, true, true);
+        emit Encumber(alice, charlie, 60e18);
+        cometWrapper.encumberFrom(alice, charlie, 60e18);
+
+        // no balance is transferred
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.balanceOf(charlie), 0);
+        // but available balance is reduced
+        assertEq(cometWrapper.availableBalanceOf(alice), 40e18);
+        // encumbrance to charlie is created
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 60e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0e18);
+        assertEq(cometWrapper.encumbrances(alice, charlie), 60e18);
+        // allowance is partially spent
+        assertEq(cometWrapper.allowance(alice, bob), 40e18);
+    }
+
+    function test_release() public {
+        deal(address(cometWrapper), alice, 100e18);
+
+        vm.prank(alice);
+
+        // alice encumbers her balance to bob
+        cometWrapper.encumber(bob, 100e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 100e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 100e18);
+
+        // bob releases part of the encumbrance
+        vm.prank(bob);
+        // emits Release event
+        vm.expectEmit(true, true, true, true);
+        emit Release(alice, bob, 40e18);
+        cometWrapper.release(alice, 40e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 40e18);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 60e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 60e18);
+    }
+
+    function test_release_revertsOnInsufficientEncumbrance() public {
+        deal(address(cometWrapper), alice, 100e18);
+
+        vm.prank(alice);
+
+        // alice encumbers her balance to bob
+        cometWrapper.encumber(bob, 100e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 100e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 100e18);
+
+        // bob releases a greater amount than is encumbered to him
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InsufficientEncumbrance.selector);
+        cometWrapper.release(alice, 200e18);
+
+        assertEq(cometWrapper.balanceOf(alice), 100e18);
+        assertEq(cometWrapper.availableBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 100e18);
+        assertEq(cometWrapper.encumbrances(alice, bob), 100e18);
+    }
+}

--- a/test/Encumber.t.sol
+++ b/test/Encumber.t.sol
@@ -250,7 +250,7 @@ abstract contract EncumberTest is CoreTest {
         assertEq(cometWrapper.allowance(alice, bob), 100e18);
         assertEq(cometWrapper.balanceOf(charlie), 0);
 
-        // but bob tries to encumber more than his allowance
+        // bob encumbers part of his allowance from alice to charlie
         vm.prank(bob);
         // emits an Encumber event
         vm.expectEmit(true, true, true, true);

--- a/test/Encumber.t.sol
+++ b/test/Encumber.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
 import { CoreTest, CometHelpers, CometWrapper, ERC20, ICometRewards } from "./CoreTest.sol";

--- a/test/MainnetUSDCTest.t.sol
+++ b/test/MainnetUSDCTest.t.sol
@@ -5,9 +5,10 @@ import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
+import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
     string public override NETWORK = "mainnet";
     uint256 public override FORK_BLOCK_NUMBER = 16617900;
 

--- a/test/MainnetWETHTest.t.sol
+++ b/test/MainnetWETHTest.t.sol
@@ -5,9 +5,10 @@ import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
+import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, RewardsTest {
+contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
     string public override NETWORK = "mainnet";
     uint256 public override FORK_BLOCK_NUMBER = 18285773;
 


### PR DESCRIPTION
This PR adds encumber (ERC7246) functionality to the Comet Wrapper. There are a couple TODOs to spend encumbrances in `withdraw` and `redeem` that will be done in a separate PR.