### PR TITLE
Add permit and encumberBySig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
 	branch = v7
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,6 @@
-ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
+ds-test/=lib/forge-std/lib/ds-test/src/
 solmate/=lib/solmate/src/
+erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
+openzeppelin-contracts/=lib/openzeppelin-contracts/
+openzeppelin/=lib/openzeppelin-contracts/contracts/

--- a/src/test/EIP1271Signer.sol
+++ b/src/test/EIP1271Signer.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+contract EIP1271Signer {
+    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
+
+    address public owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+
+    function isValidSignature(bytes32 messageHash, bytes memory signature) external view returns (bytes4) {
+        if (recoverSigner(messageHash, signature) == owner) {
+            return EIP1271_MAGIC_VALUE;
+        } else {
+            return 0xffffffff;
+        }
+    }
+
+    function recoverSigner(bytes32 messageHash, bytes memory signature) internal pure returns (address) {
+        require(signature.length == 65, "SignatureValidator#recoverSigner: invalid signature length");
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+            v := and(mload(add(signature, 65)), 255)
+        }
+
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        //
+        // Source OpenZeppelin
+        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol
+
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            revert("SignatureValidator#recoverSigner: invalid signature 's' value");
+        }
+
+        if (v != 27 && v != 28) {
+            revert("SignatureValidator#recoverSigner: invalid signature 'v' value");
+        }
+
+        // Recover ECDSA signer
+        address signer = ecrecover(messageHash, v, r, s);
+
+        // Prevent signer from being 0x0
+        require(
+            signer != address(0x0),
+            "SignatureValidator#recoverSigner: INVALID_SIGNER"
+        );
+
+        return signer;
+    }
+}

--- a/test/BaseUSDbCTest.t.sol
+++ b/test/BaseUSDbCTest.t.sol
@@ -3,12 +3,13 @@ pragma solidity 0.8.21;
 
 import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
+import { BySigTest } from "./BySig.t.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
 import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
+contract BaseUSDbCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest, BySigTest {
     string public override NETWORK = "base";
     uint256 public override FORK_BLOCK_NUMBER = 4791144;
 

--- a/test/BySig.t.sol
+++ b/test/BySig.t.sol
@@ -1,0 +1,1140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import { CoreTest, CometHelpers, CometWrapper, ERC20, ICometRewards } from "./CoreTest.sol";
+
+// Tests for `permit` and `encumberBySig`
+abstract contract BySigTest is CoreTest {
+    bytes32 internal constant AUTHORIZATION_TYPEHASH = keccak256("Authorization(address owner,address spender,uint256 amount,uint256 nonce,uint256 expiry)");
+    bytes32 internal constant ENCUMBER_TYPEHASH = keccak256("Encumber(address owner,address taker,uint256 amount,uint256 nonce,uint256 expiry)");
+
+    function aliceAuthorization(uint256 amount, uint256 nonce, uint256 expiry) internal view returns (uint8, bytes32, bytes32) {
+        bytes32 structHash = keccak256(abi.encode(AUTHORIZATION_TYPEHASH, alice, bob, amount, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", cometWrapper.DOMAIN_SEPARATOR(), structHash));
+        return vm.sign(alicePrivateKey, digest);
+    }
+
+    function aliceContractAuthorization(uint256 amount, uint256 nonce, uint256 expiry) internal view returns (uint8, bytes32, bytes32) {
+        bytes32 structHash = keccak256(abi.encode(AUTHORIZATION_TYPEHASH, aliceContract, bob, amount, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", cometWrapper.DOMAIN_SEPARATOR(), structHash));
+        return vm.sign(alicePrivateKey, digest);
+    }
+
+    function aliceEncumberAuthorization(uint256 amount, uint256 nonce, uint256 expiry) internal view returns (uint8, bytes32, bytes32) {
+        bytes32 structHash = keccak256(abi.encode(ENCUMBER_TYPEHASH, alice, bob, amount, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", cometWrapper.DOMAIN_SEPARATOR(), structHash));
+        return vm.sign(alicePrivateKey, digest);
+    }
+
+    function aliceContractEncumberAuthorization(uint256 amount, uint256 nonce, uint256 expiry) internal view returns (uint8, bytes32, bytes32) {
+        bytes32 structHash = keccak256(abi.encode(ENCUMBER_TYPEHASH, aliceContract, bob, amount, nonce, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", cometWrapper.DOMAIN_SEPARATOR(), structHash));
+        return vm.sign(alicePrivateKey, digest);
+    }
+
+    /* ===== Permit ===== */
+
+    function testPermit() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature
+        vm.prank(bob);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice equals allowance
+        assertEq(cometWrapper.allowance(alice, bob), allowance);
+
+        // alice's nonce is incremented
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+    }
+
+    function testPermitRevertsForBadOwner() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the owner
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(charlie, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsForBadSpender() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the spender
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(alice, charlie, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsForBadAmount() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the allowance
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(alice, bob, allowance + 1 wei, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsForBadExpiry() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(alice, bob, allowance, expiry + 1, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsForBadNonce() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice signs an authorization with an invalid nonce
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 badNonce = nonce + 1;
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, badNonce, expiry);
+
+        // bob calls permit with the signature with an invalid nonce
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsOnRepeatedCall() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature
+        vm.prank(bob);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice equals allowance
+        assertEq(cometWrapper.allowance(alice, bob), allowance);
+
+        // alice's nonce is incremented
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+
+        // alice revokes bob's allowance
+        vm.prank(alice);
+        cometWrapper.approve(bob, 0);
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // bob tries to reuse the same signature twice
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+    }
+
+    function testPermitRevertsForExpiredSignature() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceAuthorization(allowance, nonce, expiry);
+
+        // the expiry block arrives
+        vm.warp(expiry);
+
+        // bob calls permit with the signature after the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.SignatureExpired.selector);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsInvalidS() public {
+        // bob's allowance from alice is 0
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, ) = aliceAuthorization(allowance, nonce, expiry);
+
+        // 1 greater than the max value of s
+        bytes32 invalidS = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1;
+
+        // bob calls permit with the signature with invalid `s` value
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InvalidSignatureS.selector);
+        cometWrapper.permit(alice, bob, allowance, expiry, v, r, invalidS);
+
+        // bob's allowance from alice is unchanged
+        assertEq(cometWrapper.allowance(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    /* ===== EncumberBySig ===== */
+
+    function testEncumberBySig() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature
+        vm.prank(bob);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, s);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), encumbranceAmount);
+        assertEq(cometWrapper.encumbrances(alice, bob), encumbranceAmount);
+
+        // alice's nonce is incremented
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+    }
+
+    function testEncumberBySigRevertsForBadOwner() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the owner
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(charlie, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadSpender() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the spender
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(alice, charlie, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadAmount() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the encumbranceAmount
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount + 1 wei, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadExpiry() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry + 1, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadNonce() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice signs an authorization with an invalid nonce
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 badNonce = nonce + 1;
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, badNonce, expiry);
+
+        // bob calls encumberBySig with the signature with an invalid nonce
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsOnRepeatedCall() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+        uint256 transferAmount = 30e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature
+        vm.startPrank(bob);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, s);
+
+        // the encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), encumbranceAmount);
+        assertEq(cometWrapper.encumbrances(alice, bob), encumbranceAmount);
+
+        // alice's nonce is incremented
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+
+        // bob uses some of the encumbrance to transfer to himself
+        cometWrapper.transferFrom(alice, bob, transferAmount);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance - transferAmount);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), encumbranceAmount - transferAmount);
+        assertEq(cometWrapper.encumbrances(alice, bob), encumbranceAmount - transferAmount);
+
+        // bob tries to reuse the same signature twice
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no new encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance - transferAmount);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), encumbranceAmount - transferAmount);
+        assertEq(cometWrapper.encumbrances(alice, bob), encumbranceAmount - transferAmount);
+
+        // alice's nonce is not incremented a second time
+        assertEq(cometWrapper.nonces(alice), nonce + 1);
+
+        vm.stopPrank();
+    }
+
+    function testEncumberBySigRevertsForExpiredSignature() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        // Fix for via-IR issue: https://github.com/foundry-rs/foundry/issues/3312#issuecomment-1255264273
+        uint256 expiry = uint248(block.timestamp + 1000);
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // the expiry block arrives
+        vm.warp(expiry);
+
+        // bob calls encumberBySig with the signature after the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.SignatureExpired.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testEncumberBySigRevertsInvalidS() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice has 100 wrapped tokens
+        deal(address(cometWrapper), alice, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, ) = aliceEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // 1 greater than the max value of s
+        bytes32 invalidS = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1;
+
+        // bob calls encumberBySig with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.InvalidSignatureS.selector);
+        cometWrapper.encumberBySig(alice, bob, encumbranceAmount, expiry, v, r, invalidS);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(alice), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(alice), 0);
+        assertEq(cometWrapper.encumbrances(alice, bob), 0);
+
+        // alice's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    /* ===== EIP1271 Tests ===== */
+
+    function testPermitEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature
+        vm.prank(bob);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract equals allowance
+        assertEq(cometWrapper.allowance(aliceContract, bob), allowance);
+
+        // alice's contract's nonce is incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+    }
+
+    function testPermitRevertsForBadOwnerEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the owner
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(charlie, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsForBadSpenderEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the spender
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(aliceContract, charlie, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsForBadAmountEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the allowance
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(aliceContract, bob, allowance + 1 wei, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsForBadExpiryEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry + 1, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(alice), nonce);
+    }
+
+    function testPermitRevertsForBadNonceEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice signs an authorization with an invalid nonce
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 badNonce = nonce + 1;
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, badNonce, expiry);
+
+        // bob calls permit with the signature with an invalid nonce
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsOnRepeatedCallEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // bob calls permit with the signature
+        vm.prank(bob);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract equals allowance
+        assertEq(cometWrapper.allowance(aliceContract, bob), allowance);
+
+        // alice's contract's nonce is incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+
+        // alice revokes bob's allowance
+        vm.prank(aliceContract);
+        cometWrapper.approve(bob, 0);
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // bob tries to reuse the same signature twice
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+    }
+
+    function testPermitRevertsForExpiredSignatureEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // the expiry block arrives
+        vm.warp(expiry);
+
+        // bob calls permit with the signature after the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.SignatureExpired.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsInvalidVEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (, bytes32 r, bytes32 s) = aliceContractAuthorization(allowance, nonce, expiry);
+        uint8 invalidV = 26;
+
+        // bob calls permit with the signature with invalid `v` value
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.EIP1271VerificationFailed.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, invalidV, r, s);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testPermitRevertsInvalidSEIP1271() public {
+        // bob's allowance from alice's contract is 0
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        uint256 allowance = 123e18;
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, ) = aliceContractAuthorization(allowance, nonce, expiry);
+
+        // 1 greater than the max value of s
+        bytes32 invalidS = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1;
+
+        // bob calls permit with the signature with invalid `s` value
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.EIP1271VerificationFailed.selector);
+        cometWrapper.permit(aliceContract, bob, allowance, expiry, v, r, invalidS);
+
+        // bob's allowance from alice's contract is unchanged
+        assertEq(cometWrapper.allowance(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature
+        vm.prank(bob);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, s);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), encumbranceAmount);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), encumbranceAmount);
+
+        // alice's contract's nonce is incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+    }
+
+    function testEncumberBySigRevertsForBadSpenderEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the spender
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(aliceContract, charlie, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadAmountEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the encumbranceAmount
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount + 1 wei, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadExpiryEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry + 1, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsForBadNonceEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice signs an authorization with an invalid nonce
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 badNonce = nonce + 1;
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, badNonce, expiry);
+
+        // bob calls encumberBySig with the signature with an invalid nonce
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsOnRepeatedCallEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+        uint256 transferAmount = 30e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(alice);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // bob calls encumberBySig with the signature
+        vm.startPrank(bob);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, s);
+
+        // the encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), encumbranceAmount);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), encumbranceAmount);
+
+        // alice's contract's nonce is incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+
+        // bob uses some of the encumbrance to transfer to himself
+        cometWrapper.transferFrom(aliceContract, bob, transferAmount);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance - transferAmount);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), encumbranceAmount - transferAmount);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), encumbranceAmount - transferAmount);
+
+        // bob tries to reuse the same signature twice
+        vm.expectRevert(CometWrapper.BadSignatory.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no new encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance - transferAmount);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance - encumbranceAmount);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), encumbranceAmount - transferAmount);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), encumbranceAmount - transferAmount);
+
+        // alice's contract's nonce is not incremented a second time
+        assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
+
+        vm.stopPrank();
+    }
+
+    function testEncumberBySigRevertsForExpiredSignatureEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        // Fix for via-IR issue: https://github.com/foundry-rs/foundry/issues/3312#issuecomment-1255264273
+        uint256 expiry = uint248(block.timestamp + 1000);
+
+        (uint8 v, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // the expiry block arrives
+        vm.warp(expiry);
+
+        // bob calls encumberBySig with the signature after the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.SignatureExpired.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsInvalidVEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (, bytes32 r, bytes32 s) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+        uint8 invalidV = 26;
+
+        // bob calls encumberBySig with the signature with an invalid `v` value
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.EIP1271VerificationFailed.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, invalidV, r, s);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+
+    function testEncumberBySigRevertsInvalidSEIP1271() public {
+        uint256 aliceBalance = 100e18;
+        uint256 encumbranceAmount = 60e18;
+
+        // alice's contract has 100 wrapped tokens
+        deal(address(cometWrapper), aliceContract, aliceBalance);
+
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        uint256 nonce = cometWrapper.nonces(aliceContract);
+        uint256 expiry = block.timestamp + 1000;
+
+        (uint8 v, bytes32 r, ) = aliceContractEncumberAuthorization(encumbranceAmount, nonce, expiry);
+
+        // 1 greater than the max value of s
+        bytes32 invalidS = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1;
+
+        // bob calls encumberBySig with the signature, but he manipulates the expiry
+        vm.prank(bob);
+        vm.expectRevert(CometWrapper.EIP1271VerificationFailed.selector);
+        cometWrapper.encumberBySig(aliceContract, bob, encumbranceAmount, expiry, v, r, invalidS);
+
+        // no encumbrance is created
+        assertEq(cometWrapper.balanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.availableBalanceOf(aliceContract), aliceBalance);
+        assertEq(cometWrapper.encumberedBalanceOf(aliceContract), 0);
+        assertEq(cometWrapper.encumbrances(aliceContract, bob), 0);
+
+        // alice's contract's nonce is not incremented
+        assertEq(cometWrapper.nonces(aliceContract), nonce);
+    }
+}

--- a/test/BySig.t.sol
+++ b/test/BySig.t.sol
@@ -34,7 +34,7 @@ abstract contract BySigTest is CoreTest {
 
     /* ===== Permit ===== */
 
-    function testPermit() public {
+    function test_permit() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -55,7 +55,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce + 1);
     }
 
-    function testPermitRevertsForBadOwner() public {
+    function test_permit_revertsForBadOwner() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -77,7 +77,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsForBadSpender() public {
+    function test_permit_revertsForBadSpender() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -99,7 +99,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsForBadAmount() public {
+    function test_permit_revertsForBadAmount() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -121,7 +121,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsForBadExpiry() public {
+    function test_permit_revertsForBadExpiry() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -143,7 +143,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsForBadNonce() public {
+    function test_permit_revertsForBadNonce() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -167,7 +167,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsOnRepeatedCall() public {
+    function test_permit_revertsOnRepeatedCall() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -204,7 +204,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce + 1);
     }
 
-    function testPermitRevertsForExpiredSignature() public {
+    function test_permit_revertsForExpiredSignature() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -229,7 +229,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsInvalidS() public {
+    function test_permit_revertsInvalidS() public {
         // bob's allowance from alice is 0
         assertEq(cometWrapper.allowance(alice, bob), 0);
 
@@ -256,7 +256,7 @@ abstract contract BySigTest is CoreTest {
 
     /* ===== EncumberBySig ===== */
 
-    function testEncumberBySig() public {
+    function test_encumberBySig() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -286,7 +286,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce + 1);
     }
 
-    function testEncumberBySigRevertsForBadOwner() public {
+    function test_encumberBySig_revertsForBadOwner() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -318,7 +318,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsForBadSpender() public {
+    function test_encumberBySig_revertsForBadSpender() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -350,7 +350,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsForBadAmount() public {
+    function test_encumberBySig_revertsForBadAmount() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -382,7 +382,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsForBadExpiry() public {
+    function test_encumberBySig_revertsForBadExpiry() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -414,7 +414,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsForBadNonce() public {
+    function test_encumberBySig_revertsForBadNonce() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -448,7 +448,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsOnRepeatedCall() public {
+    function test_encumberBySig_revertsOnRepeatedCall() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
         uint256 transferAmount = 30e18;
@@ -503,7 +503,7 @@ abstract contract BySigTest is CoreTest {
         vm.stopPrank();
     }
 
-    function testEncumberBySigRevertsForExpiredSignature() public {
+    function test_encumberBySig_revertsForExpiredSignature() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -539,7 +539,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testEncumberBySigRevertsInvalidS() public {
+    function test_encumberBySig_revertsInvalidS() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -576,7 +576,7 @@ abstract contract BySigTest is CoreTest {
 
     /* ===== EIP1271 Tests ===== */
 
-    function testPermitEIP1271() public {
+    function test_permitEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -597,7 +597,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
     }
 
-    function testPermitRevertsForBadOwnerEIP1271() public {
+    function test_permit_revertsForBadOwnerEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -619,7 +619,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsForBadSpenderEIP1271() public {
+    function test_permit_revertsForBadSpenderEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -641,7 +641,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsForBadAmountEIP1271() public {
+    function test_permit_revertsForBadAmountEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -663,7 +663,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsForBadExpiryEIP1271() public {
+    function test_permit_revertsForBadExpiryEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -685,7 +685,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(alice), nonce);
     }
 
-    function testPermitRevertsForBadNonceEIP1271() public {
+    function test_permit_revertsForBadNonceEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -709,7 +709,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsOnRepeatedCallEIP1271() public {
+    function test_permit_revertsOnRepeatedCallEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -746,7 +746,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
     }
 
-    function testPermitRevertsForExpiredSignatureEIP1271() public {
+    function test_permit_revertsForExpiredSignatureEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -771,7 +771,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsInvalidVEIP1271() public {
+    function test_permit_revertsInvalidVEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -794,7 +794,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testPermitRevertsInvalidSEIP1271() public {
+    function test_permit_revertsInvalidSEIP1271() public {
         // bob's allowance from alice's contract is 0
         assertEq(cometWrapper.allowance(aliceContract, bob), 0);
 
@@ -819,7 +819,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigEIP1271() public {
+    function test_encumberBySigEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -849,7 +849,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce + 1);
     }
 
-    function testEncumberBySigRevertsForBadSpenderEIP1271() public {
+    function test_encumberBySig_revertsForBadSpenderEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -881,7 +881,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsForBadAmountEIP1271() public {
+    function test_encumberBySig_revertsForBadAmountEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -913,7 +913,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsForBadExpiryEIP1271() public {
+    function test_encumberBySig_revertsForBadExpiryEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -945,7 +945,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsForBadNonceEIP1271() public {
+    function test_encumberBySig_revertsForBadNonceEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -979,7 +979,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsOnRepeatedCallEIP1271() public {
+    function test_encumberBySig_revertsOnRepeatedCallEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
         uint256 transferAmount = 30e18;
@@ -1034,7 +1034,7 @@ abstract contract BySigTest is CoreTest {
         vm.stopPrank();
     }
 
-    function testEncumberBySigRevertsForExpiredSignatureEIP1271() public {
+    function test_encumberBySig_revertsForExpiredSignatureEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -1070,7 +1070,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsInvalidVEIP1271() public {
+    function test_encumberBySig_revertsInvalidVEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 
@@ -1103,7 +1103,7 @@ abstract contract BySigTest is CoreTest {
         assertEq(cometWrapper.nonces(aliceContract), nonce);
     }
 
-    function testEncumberBySigRevertsInvalidSEIP1271() public {
+    function test_encumberBySig_revertsInvalidSEIP1271() public {
         uint256 aliceBalance = 100e18;
         uint256 encumbranceAmount = 60e18;
 

--- a/test/CoreTest.sol
+++ b/test/CoreTest.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.21;
 
 import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
+import { EIP1271Signer } from "../src/test/EIP1271Signer.sol";
 
 abstract contract CoreTest is Test {
     function NETWORK() external virtual returns (string calldata);
@@ -34,9 +35,12 @@ abstract contract CoreTest is Test {
     address public wrapperAddress;
     uint256 public decimalScale;
 
-    address alice = address(0xABCD);
+    uint256 alicePrivateKey = 0xa11ce;
+    address alice = vm.addr(alicePrivateKey);
     address bob = address(0xDCBA);
     address charlie = address(0xCDAB);
+
+    address aliceContract; // contract that can verify EIP1271 signatures
 
     function setUp() public virtual {
         vm.label(alice, "alice");
@@ -61,6 +65,7 @@ abstract contract CoreTest is Test {
             new CometWrapper(ERC20(cometAddress), ICometRewards(rewardAddress), "Wrapped Comet UNDERLYING", "WcUNDERLYINGv3");
         wrapperAddress = address(cometWrapper);
         decimalScale = 10 ** underlyingToken.decimals();
+        aliceContract = address(new EIP1271Signer(alice));
     }
 
     function setUpFuzzTestAssumptions(uint256 amount) public view returns (uint256) {

--- a/test/MainnetUSDCTest.t.sol
+++ b/test/MainnetUSDCTest.t.sol
@@ -3,12 +3,13 @@ pragma solidity 0.8.21;
 
 import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
+import { BySigTest } from "./BySig.t.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
 import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
+contract MainnetUSDCTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest, BySigTest {
     string public override NETWORK = "mainnet";
     uint256 public override FORK_BLOCK_NUMBER = 16617900;
 

--- a/test/MainnetWETHTest.t.sol
+++ b/test/MainnetWETHTest.t.sol
@@ -3,12 +3,13 @@ pragma solidity 0.8.21;
 
 import { Test } from "forge-std/Test.sol";
 import { CometWrapper, CometInterface, ICometRewards, CometHelpers, ERC20 } from "../src/CometWrapper.sol";
+import { BySigTest } from "./BySig.t.sol";
 import { CometWrapperTest } from "./CometWrapper.t.sol";
 import { CometWrapperInvariantTest } from "./CometWrapperInvariant.t.sol";
 import { EncumberTest } from "./Encumber.t.sol";
 import { RewardsTest } from "./Rewards.t.sol";
 
-contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest {
+contract MainnetWETHTest is CometWrapperTest, CometWrapperInvariantTest, EncumberTest, RewardsTest, BySigTest {
     string public override NETWORK = "mainnet";
     uint256 public override FORK_BLOCK_NUMBER = 18285773;
 


### PR DESCRIPTION
Implements `permit` and `encumberBySig`, both of which support EIP-1271 signatures.